### PR TITLE
Feature/stm32 mcu

### DIFF
--- a/endaq/device/__init__.py
+++ b/endaq/device/__init__.py
@@ -204,8 +204,8 @@ def onRecorder(path: Filename) -> bool:
     """ Returns the root directory of a recorder from a path to a directory or
         file on that recorder. It can be used to test whether a file is on
         a recorder. `False` is returned if the path is not on a recorder.
-        The test is only whether the path refers to a recorder, not whether or 
-        not the path or file actually exists; if you need to know if the path 
+        The test is only whether the path refers to a recorder, not whether
+        the path or file actually exists; if you need to know if the path
         is valid, perform your own checks first.
         
         :param path: The full path/name of a file.

--- a/endaq/device/base.py
+++ b/endaq/device/base.py
@@ -221,7 +221,7 @@ class Recorder:
             self._channelRanges = {}
             self._manifest = None
             self._calibration = None
-            self._calData = None
+            self._calData = None  # Note: unlike _manData, _calData is raw
             self._calPolys = None
             self._userCalPolys = None
             self._userCalDict = None
@@ -652,6 +652,8 @@ class Recorder:
     @property
     def postConfigMsg(self) -> str:
         """ The message to be displayed after configuration. """
+        if not self.isVirtual and self.config and self.config.postConfigMsg:
+            return self.config.postConfigMsg
         return self._POST_CONFIG_MSG
 
 

--- a/endaq/device/base.py
+++ b/endaq/device/base.py
@@ -92,11 +92,14 @@ class Recorder:
 
 
     def __init__(self, path: Optional[Filename], strict=True, **kwargs):
-        """ Constructor.
+        """ Constructor. Typically, instantiation should be done indirectly,
+            using `endaq.device.getDevices()` or `endaq.device.fromRecording()`.
+            Explicitly instantiating a `Recorder` or `Recorder` subclass is
+            rarely (if ever) necessary.
 
             :param path: The filesystem path to the recorder, or `None` if
-                it is a 'virtual' device (e.g., constructed from data
-                in a recording).
+                it is a 'virtual' device (e.g., constructed from data in a
+                recording).
             :param strict: If `True`, only allow real device paths. If
                 `False`, allow any path that contains a recorder's
                 ``SYSTEM`` directory. Primarily for testing.

--- a/endaq/device/command_interfaces.py
+++ b/endaq/device/command_interfaces.py
@@ -366,9 +366,9 @@ class CommandInterface:
             :param interval: Time (in seconds) between checks for a
                 response.
             :param callback: A function to call each response-checking
-                cycle. If the callback returns `True`, the wait for a response
-                will be cancelled. The callback function should take no
-                arguments.
+                cycle. If the callback returns `True`, the wait for a
+                response will be cancelled. The callback function
+                requires no arguments.
 
             @raise DeviceTimeout
         """
@@ -395,9 +395,9 @@ class CommandInterface:
             :param timeout: Time (in seconds) to wait for the recorder to
                 respond. 0 will return immediately.
             :param callback: A function to call each response-checking
-                cycle. If the callback returns `True`, the wait for a response
-                will be cancelled. The callback function should take no
-                arguments.
+                cycle. If the callback returns `True`, the wait for a
+                response will be cancelled. The callback function should
+                require no arguments.
             :returns: `True` if the command was successful.
         """
         self._sendCommand(cmd, response=False, timeout=timeout, callback=callback)
@@ -422,9 +422,9 @@ class CommandInterface:
             :param timeout: Time (in seconds) to wait for the recorder to
                 respond. 0 will return immediately.
             :param callback: A function to call each response-checking
-                cycle. If the callback returns `True`, the wait for a response
-                will be cancelled. The callback function should take no
-                arguments.
+                cycle. If the callback returns `True`, the wait for a
+                response will be cancelled. The callback function should
+                require no arguments.
             :returns: `True` if the command was successful.
         """
         raise NotImplementedError
@@ -439,9 +439,9 @@ class CommandInterface:
             :param timeout: Time (in seconds) to wait for the recorder to
                 respond. 0 will return immediately.
             :param callback: A function to call each response-checking
-                cycle. If the callback returns `True`, the wait for a response
-                will be cancelled. The callback function should take no
-                arguments.
+                cycle. If the callback returns `True`, the wait for a
+                response will be cancelled. The callback function should
+                require no arguments.
             :returns: `True` if the command was successful.
         """
         raise NotImplementedError
@@ -456,9 +456,9 @@ class CommandInterface:
             :param timeout: Time (in seconds) to wait for the recorder to
                 respond. 0 will return immediately.
             :param callback: A function to call each response-checking
-                cycle. If the callback returns `True`, the wait for a response
-                will be cancelled. The callback function should take no
-                arguments.
+                cycle. If the callback returns `True`, the wait for a
+                response will be cancelled. The callback function should
+                require no arguments.
             :return:
         """
         # Only interfaces that support this method will implement it.
@@ -477,9 +477,9 @@ class CommandInterface:
             :param timeout: Time (in seconds) to wait for the recorder to
                 respond. 0 will return immediately.
             :param callback: A function to call each response-checking
-                cycle. If the callback returns `True`, the wait for a response
-                will be cancelled. The callback function should take no
-                arguments.
+                cycle. If the callback returns `True`, the wait for a
+                response will be cancelled. The callback function should
+                require no arguments.
             :return: The received data, which should be identical to the
                 data sent.
         """
@@ -507,9 +507,9 @@ class CommandInterface:
             :param timeoutMsg: A command-specific message to use when raising
                 a `DeviceTimeout` exception.
             :param callback: A function to call each response-checking
-                cycle. If the callback returns `True`, the wait for a response
-                will be cancelled. The callback function should take no
-                arguments.
+                cycle. If the callback returns `True`, the wait for a
+                response will be cancelled. The callback function should
+                require no arguments.
             :return: `True` if the device unmounted. `False` if it is a
                 virtual device, or the wait was cancelled by the callback.
         """
@@ -546,9 +546,9 @@ class CommandInterface:
                 dismount, implying the updates are being applied. 0 will
                 return immediately.
             :param callback: A function to call each response-checking
-                cycle. If the callback returns `True`, the wait for a response
-                will be cancelled. The callback function should take no
-                arguments.
+                cycle. If the callback returns `True`, the wait for a
+                response will be cancelled. The callback function should
+                require no arguments.
             :returns: `True` if the command was successful.
         """
         raise NotImplementedError
@@ -618,9 +618,9 @@ class CommandInterface:
                 dismount, implying the updates are being applied. 0 will
                 return immediately.
             :param callback: A function to call each response-checking
-                cycle. If the callback returns `True`, the wait for a response
-                will be cancelled. The callback function should take no
-                arguments.
+                cycle. If the callback returns `True`, the wait for a
+                response will be cancelled. The callback function should
+                require no arguments.
             :returns: `True` if the device rebooted. This does not indicate
                 that the updates were successfully applied.
         """
@@ -668,9 +668,9 @@ class CommandInterface:
             :param timeout: Time (in seconds) to wait for the recorder to
                 respond. 0 will return immediately.
             :param callback: A function to call each response-checking
-                cycle. If the callback returns `True`, the wait for a response
-                will be cancelled. The callback function should take no
-                arguments.
+                cycle. If the callback returns `True`, the wait for a
+                response will be cancelled. The callback function should
+                require no arguments.
             :return:
         """
         cmd = {'EBMLCommand': {'SetKeys': keys}}
@@ -746,9 +746,10 @@ class CommandInterface:
             :param timeout: Time (in seconds) to wait for a response before
                 raising a `DeviceTimeout` exception.
             :param interval: Time (in seconds) between checks for a response.
-            :param callback: A function to call each response-checking cycle.
-                If the callback returns `True`, the wait for a response will be
-                cancelled. The callback function should take no arguments.
+            :param callback: A function to call each response-checking
+                cycle. If the callback returns `True`, the wait for a
+                response will be cancelled. The callback function should
+                require no arguments.
             :return: None if no information was recieved, else it will return
                 the information from the ``QueryWiFiResponse`` command (this
                 return statement is not used anywhere)
@@ -783,7 +784,8 @@ class CommandInterface:
             :param interval: Time (in seconds) between checks for a response.
             :param callback: A function to call each response-checking cycle.
                 If the callback returns `True`, the wait for a response will
-                be cancelled. The callback function should take no arguments.
+                be cancelled. The callback function should require no
+                arguments.
 
             :return: A list of dictionaries, one for each access point,
                 with keys:
@@ -839,9 +841,9 @@ class CommandInterface:
             :param timeout: Time (in seconds) to wait for the recorder to
                 respond. 0 will return immediately.
             :param callback: A function to call each response-checking
-                cycle. If the callback returns `True`, the wait for a response
-                will be cancelled. The callback function should take no
-                arguments.
+                cycle. If the callback returns `True`, the wait for a
+                response will be cancelled. The callback function should
+                require no arguments.
             :return:
         """
         # FUTURE: This (and other file-based update) will need refactoring
@@ -1121,9 +1123,9 @@ class SerialCommandInterface(CommandInterface):
 
         :param timeout: Time to wait for a valid response.
         :param callback: A function to call each response-checking
-            cycle. If the callback returns `True`, the wait for a response
-            will be cancelled. The callback function should take no
-            arguments.
+            cycle. If the callback returns `True`, the wait for a
+            response will be cancelled. The callback function should
+            require no arguments.
         :return: A `dict` of response data, or `None` if `callback` caused
             the process to cancel.
         """
@@ -1180,9 +1182,9 @@ class SerialCommandInterface(CommandInterface):
             :param index: If `True` (default), include an incrementing
                 'command index' (for matching responses to commands).
             :param callback: A function to call each response-checking
-                cycle. If the callback returns `True`, the wait for a response
-                will be cancelled. The callback function should take no
-                arguments.
+                cycle. If the callback returns `True`, the wait for a
+                response will be cancelled. The callback function should
+                require no arguments.
             :return: The response dictionary, or `None` if `response` is
                 `False`.
 
@@ -1804,6 +1806,7 @@ class FileCommandInterface(CommandInterface):
 # ===========================================================================
 
 #: A list of all `CommandInterface` types, used when finding a device's
-#   interface. `FileCommandInterface` should go last. New interface types
+#   interface. `FileCommandInterface` should go last, since devices with
+#   "better" interfaces may support it as a fallback. New interface types
 #   defined elsewhere should append/insert themselves into this list.
 INTERFACES = [SerialCommandInterface, FileCommandInterface]

--- a/endaq/device/command_interfaces.py
+++ b/endaq/device/command_interfaces.py
@@ -1082,7 +1082,7 @@ class SerialCommandInterface(CommandInterface):
         # method cannot directly decode a packet created by `encode()`.
 
         # Messages are Corbus packets:
-        # HDLC escaped, short header, payload, crc16
+        # HDLC escaped short header, payload, crc16
         packet = hdlc_decode(packet, ignore_crc=self.ignore_crc)
         if packet.startswith(b'\x81\x00'):
             resultcode = packet[2]
@@ -1359,7 +1359,7 @@ class SerialCommandInterface(CommandInterface):
 
     def getBatteryStatus(self,
                          timeout: float = 1,
-                         callback: Optional[Callable] = None) -> dict:
+                         callback: Optional[Callable] = None) -> Union[dict, None]:
         """ Get the status of the recorder's battery. Not supported on all
             devices.
 
@@ -1385,7 +1385,10 @@ class SerialCommandInterface(CommandInterface):
         """
         cmd = {'EBMLCommand': {'GetBattery': {}}}
         response = self._sendCommand(cmd, timeout=timeout,
-                                    callback=callback).get('BatteryState')
+                                    callback=callback)
+        if not response:
+            return None
+        response = response.get('BatteryState')
 
         hasBattery = bool(response & 0x8000)
         reply = {'hasBattery': hasBattery}

--- a/endaq/device/command_interfaces.py
+++ b/endaq/device/command_interfaces.py
@@ -569,6 +569,8 @@ class CommandInterface:
                 process, i.e., it was successfully copied, or already exists
                 (if `filename` is `None` and not `clean`).
         """
+        # filename is checked 2x, before cleaning and before copying, so
+        # nothing gets removed if given a bad (non-None) filename.
         if filename:
             clean = True
             if not os.path.isfile(filename):
@@ -593,13 +595,13 @@ class CommandInterface:
                      firmware: Optional[str] = None,
                      userpage: Optional[str] = None,
                      clean: bool = False,
-                     timeout: float = 10,
+                     timeout: float = 10.0,
                      callback: Optional[Callable] = None) -> bool:
-        """ Apply a firmware package and/or device description data to the
-            device. If no filenames are supplied, it will be assumed that one
-            or both of the update files have been manually copied to the
-            recorder; a `FileNotFound` exception will be raised if neither
-            exist on the device.
+        """ Apply a firmware package and/or device description data update
+            to the device. If no filenames are supplied, it will be assumed
+            that one or both of the update files have been manually copied
+            to the recorder; a `FileNotFound` exception will be raised if
+            neither exist on the device.
 
             :param firmware: The name of the firmware file (typically
                 `".pkg"`, or `".bin"` on older devices). If provided, any
@@ -610,7 +612,7 @@ class CommandInterface:
                 userpage update files already on the device will be
                 overwritten. Warning: userpage data is specific to an
                 individual recorder. Do not install a userpage file created
-                for a different device.
+                for a different device!
             :param clean: If `True`, any existing firmware or userpage
                 update files will be removed from the device. Used if either
                 `firmware` or `userpage` is supplied (but not both).

--- a/endaq/device/endaq.py
+++ b/endaq/device/endaq.py
@@ -42,6 +42,7 @@ class EndaqW(EndaqS):
     # Part number starts with "W", a 1-2 digit number, and "-"
     _NAME_PATTERN = re.compile(r'^W(\d|\d\d)-.*')
 
+    # These are now in CommandInterface, and will eventually be removed here
     WIFI_STATUS_IDLE = 0
     WIFI_STATUS_PENDING = 1
     WIFI_STATUS_CONNECTED = 2
@@ -91,7 +92,7 @@ class EndaqW(EndaqS):
             :param interval: Time (in seconds) between checks for a response.
             :param callback: A function to call each response-checking cycle.
                 If the callback returns `True`, the wait for a response will be
-                cancelled. The callback function should take no arguments.
+                cancelled. The callback function should require no arguments.
 
             :raise DeviceTimeout: Raised if 'timeout' seconds have gone by
                 without getting a response
@@ -128,7 +129,7 @@ class EndaqW(EndaqS):
             :param interval: Time (in seconds) between checks for a response.
             :param callback: A function to call each response-checking cycle.
                 If the callback returns `True`, the wait for a response will be
-                cancelled. The callback function should take no arguments.
+                cancelled. The callback function should require no arguments.
             :return: None if no information was recieved, else it will return
                 the information from the ``QueryWiFiResponse`` command (this
                 return statement is not used anywhere)

--- a/endaq/device/slamstick.py
+++ b/endaq/device/slamstick.py
@@ -42,9 +42,11 @@ class SlamStickX(Recorder):
     def usesOldConfig(self) -> bool:
         """ Can this device use the 'old' configuration format?
         """
-        if self.getInfo('McuType', '').startswith("EFM32GG11"):
-            return False
-        return self.firmwareVersion <= 14
+        # Very old FW does not report McuType, but only runs on EFM32GG330
+        mcu = self.getInfo('McuType', 'EFM32GG330')
+        if not mcu or mcu.startswith("EFM32GG330"):
+            return self.firmwareVersion <= 14
+        return False
 
 
     def _parseConfig(self, devinfo: dict, default: Optional[dict] = None) -> dict:


### PR DESCRIPTION
This primarily provides basic support for upcoming devices using an STM32 microcontroller.
* Recognizes STM32 devices.
* Manifest and factory calibration read from separate files (`SYSTEM/DEV/MANIFEST` and `SYSTEM/DEV/SYSCAL`) if there is no set of EFM32-specific `USERPAGE` files.
* Removed cached EBML schema, so the schema path can be changed more easily (helpful for including `endaq.device` in packaged executables, _a la_ PyInstaller).
* Made various command interface methods 'private'.
* Docstring and code cleanup.