### PR TITLE
Feature/path abstraction

### DIFF
--- a/endaq/device/base.py
+++ b/endaq/device/base.py
@@ -63,9 +63,16 @@ class Recorder:
     _RECPROP_FILE = os.path.join("SYSTEM", "DEV", "DEVPROPS")
     _CONFIG_UI_FILE = os.path.join("SYSTEM", "CONFIG.UI")
     _COMMAND_FILE = os.path.join("SYSTEM", "DEV", "COMMAND")
+
+    # Manifest and factory cal data on EFM32-based devices
+    _USERPAGE_FILE = os.path.join("SYSTEM", "DEV", "USERPG%d")
+
+    # Manifest and factory cal data on other devices (STM32)
+    _SYSCAL_FILE = os.path.join("SYSTEM", "DEV", "syscal")
+    _MANIFEST_FILE = os.path.join("SYSTEM", "DEV", "manifest")
+
     _CONFIG_FILE = os.path.join("SYSTEM", "config.cfg")
     _USERCAL_FILE = os.path.join("SYSTEM", "usercal.dat")
-
     _FW_UPDATE_FILE = os.path.join('SYSTEM', 'update.pkg')
     _RESPONSE_FILE = os.path.join('SYSTEM', 'DEV', 'RESPONSE')
     _BOOTLOADER_UPDATE_FILE = os.path.join("SYSTEM", 'boot.bin')
@@ -958,10 +965,9 @@ class Recorder:
             return self._manifest
 
         # Recombine all the 'user page' files
-        systemPath = os.path.join(self.path, 'SYSTEM', 'DEV')
         data = bytearray()
         for i in range(4):
-            filename = os.path.join(systemPath, 'USERPG%d' % i)
+            filename = os.path.join(self.path, self._USERPAGE_FILE % i)
             with open(filename, 'rb') as fs:
                 data.extend(fs.read())
 
@@ -1006,8 +1012,8 @@ class Recorder:
             cached for backwards compatibility, since one or both are in the
             older devices' EFM32 'userpage'.
         """
-        manFile = os.path.join(self.path, 'SYSTEM', 'DEV', 'MANIFEST')
-        calFile = os.path.join(self.path, 'SYSTEM', 'DEV', 'SYSCAL')
+        manFile = os.path.join(self.path, self._MANIFEST_FILE)
+        calFile = os.path.join(self.path, self._SYSCAL_FILE)
 
         try:
             self._manData = loadSchema("mide_manifest.xml").load(manFile)
@@ -1040,10 +1046,9 @@ class Recorder:
             if self.isVirtual or self._manifest is not None:
                 return self._manifest
 
-            systemPath = os.path.join(self.path, 'SYSTEM', 'DEV')
-            if os.path.exists(os.path.join(systemPath, 'USERPG0')):
+            if os.path.exists(os.path.join(self.path, self._USERPAGE_FILE % 0)):
                 self._readUserpage()
-            elif os.path.exists(os.path.join(systemPath, 'MANIFEST')):
+            elif os.path.exists(os.path.join(self.path, self._MANIFEST_FILE)):
                 self._readManifest()
 
             return self._manifest

--- a/endaq/device/config.py
+++ b/endaq/device/config.py
@@ -982,16 +982,18 @@ class FileConfigInterface(ConfigInterface):
                 config file).
         """
         config = self._makeConfig(unknown)
+        configEbml = self.schema.encode(config, headers=False)
+
         try:
             util.makeBackup(self.device.configFile)
             with open(self.device.configFile, 'wb') as f:
-                self.schema.encode(f, config, headers=False)
-            self.getChanges()  # to clear the change list
-
+                f.write(configEbml)
         except Exception:
-            util.restoreBackup(self.device.configFile)
+            # Write failed, restore old config file
+            util.restoreBackup(self.device.configFile, remove=False)
             raise
 
+        self.getChanges()  # to clear the change list
 
 
 # ===========================================================================

--- a/endaq/device/util.py
+++ b/endaq/device/util.py
@@ -4,13 +4,15 @@ Some basic utility functions, for internal use.
 
 import errno
 import os.path
+import pathlib
 import shutil
+import typing
 
 import logging
 logger = logging.getLogger("endaq.device")
 
 
-def makeBackup(filename):
+def makeBackup(filename: typing.Union[str, pathlib.Path]) -> bool:
     """ Create a backup copy of the given file. For use in conjunction with
         `restoreBackup()`.
     """
@@ -25,7 +27,8 @@ def makeBackup(filename):
     return False
 
 
-def restoreBackup(filename, remove=False):
+def restoreBackup(filename: typing.Union[str, pathlib.Path],
+                  remove: bool = False) -> bool:
     """ Restore a backup copy of a file, overwriting the file. For use in
         conjunction with `makeBackup()`.
     """

--- a/tests/test__basics.py
+++ b/tests/test__basics.py
@@ -1,3 +1,7 @@
+"""
+Initial 'sanity check' identification and instantiation tests. Perform early.
+"""
+
 import os.path
 import pytest
 

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -1,0 +1,16 @@
+import pytest
+
+import endaq.device
+from endaq.device import command_interfaces
+
+from .fake_recorders import RECORDER_PATHS
+
+endaq.device.RECORDERS.clear()  # Clear any cached devices, just to be safe
+DEVICES = [endaq.device.getRecorder(path, strict=False) for path in RECORDER_PATHS]
+
+
+@pytest.mark.parametrize("dev", DEVICES)
+def test_command_basics(dev):
+    """ Confirm there is default ConfigUI data for each fake recorder.
+    """
+    assert isinstance(dev.command, command_interfaces.CommandInterface)

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -1,12 +1,17 @@
+import os.path
 import pytest
 
 import endaq.device
+from endaq.device import getRecorder
 from endaq.device import command_interfaces
 
 from .fake_recorders import RECORDER_PATHS
 
-endaq.device.RECORDERS.clear()  # Clear any cached devices, just to be safe
-DEVICES = [endaq.device.getRecorder(path, strict=False) for path in RECORDER_PATHS]
+# Clear any cached devices, just to be safe
+endaq.device.RECORDERS.clear()
+
+# Create parameters, mainly to provide an ID, making the results readable
+DEVICES = [pytest.param(getRecorder(path, strict=False), id=os.path.basename(path)) for path in RECORDER_PATHS]
 
 
 @pytest.mark.parametrize("dev", DEVICES)

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -1,3 +1,7 @@
+"""
+Tests of the command interfaces.
+"""
+
 import os.path
 import pytest
 
@@ -16,6 +20,7 @@ DEVICES = [pytest.param(getRecorder(path, strict=False), id=os.path.basename(pat
 
 @pytest.mark.parametrize("dev", DEVICES)
 def test_command_basics(dev):
-    """ Confirm there is default ConfigUI data for each fake recorder.
+    """ Initial 'sanity test' to verify `CommandInterface` instances are
+        being instantiated.
     """
     assert isinstance(dev.command, command_interfaces.CommandInterface)

--- a/tests/test_config_basic.py
+++ b/tests/test_config_basic.py
@@ -1,12 +1,17 @@
+import os.path
 import pytest
 
 import endaq.device
+from endaq.device import getRecorder
 from endaq.device import config, ui_defaults
 
 from .fake_recorders import RECORDER_PATHS
 
-endaq.device.RECORDERS.clear()  # Clear any cached devices, just to be safe
-DEVICES = [endaq.device.getRecorder(path, strict=False) for path in RECORDER_PATHS]
+# Clear any cached devices, just to be safe
+endaq.device.RECORDERS.clear()
+
+# Create parameters, mainly to provide an ID, making the results readable
+DEVICES = [pytest.param(getRecorder(path, strict=False), id=os.path.basename(path)) for path in RECORDER_PATHS]
 
 
 @pytest.mark.parametrize("dev", DEVICES)

--- a/tests/test_config_basic.py
+++ b/tests/test_config_basic.py
@@ -1,15 +1,25 @@
 import pytest
 
 import endaq.device
-from endaq.device import ui_defaults
+from endaq.device import config, ui_defaults
 
 from .fake_recorders import RECORDER_PATHS
 
+endaq.device.RECORDERS.clear()  # Clear any cached devices, just to be safe
+DEVICES = [endaq.device.getRecorder(path, strict=False) for path in RECORDER_PATHS]
 
-@pytest.mark.parametrize("path", RECORDER_PATHS)
-def test_configui_defaults(path):
+
+@pytest.mark.parametrize("dev", DEVICES)
+def test_config_basics(dev):
+    """ Initial 'sanity test' to verify `ConfigInterface` instances are
+        being instantiated.
+    """
+    # dev = endaq.device.getRecorder(path, strict=False)
+    assert isinstance(dev.config, config.ConfigInterface)
+
+
+@pytest.mark.parametrize("dev", DEVICES)
+def test_configui_defaults(dev):
     """ Confirm there is default ConfigUI data for each fake recorder.
     """
-    endaq.device.RECORDERS.clear()  # Clear cached devices, just to be safe
-    dev = endaq.device.getRecorder(path, strict=False)
     assert ui_defaults.getDefaultConfigUI(dev) is not None

--- a/tests/test_config_basic.py
+++ b/tests/test_config_basic.py
@@ -1,3 +1,7 @@
+"""
+Configuration interface tests.
+"""
+
 import os.path
 import pytest
 
@@ -19,7 +23,6 @@ def test_config_basics(dev):
     """ Initial 'sanity test' to verify `ConfigInterface` instances are
         being instantiated.
     """
-    # dev = endaq.device.getRecorder(path, strict=False)
     assert isinstance(dev.config, config.ConfigInterface)
 
 

--- a/tests/test_endaq_device.py
+++ b/tests/test_endaq_device.py
@@ -14,7 +14,7 @@ def test_basic_identification(path):
     assert endaq.device.isRecorder(path, strict=False)
 
 
-def test_identification_fail():
+def test_identification_negative():
     """ Test a non-recorder path to verify it isn't misidentified.
     """
     # Using the test file's directory because it's handy.

--- a/tests/test_endaq_device.py
+++ b/tests/test_endaq_device.py
@@ -5,6 +5,9 @@ import endaq.device
 
 from .fake_recorders import RECORDER_PATHS
 
+# Create parameters, mainly to provide an ID, making the results more readable
+RECORDER_PATHS = [pytest.param(path, id=os.path.basename(path)) for path in RECORDER_PATHS]
+
 
 @pytest.mark.parametrize("path", RECORDER_PATHS)
 def test_basic_identification(path):

--- a/tests/test_endaq_device.py
+++ b/tests/test_endaq_device.py
@@ -8,12 +8,24 @@ from .fake_recorders import RECORDER_PATHS
 
 @pytest.mark.parametrize("path", RECORDER_PATHS)
 def test_basic_identification(path):
+    """ Basic test of recorder identification. All test 'fake recorders'
+        should be identified.
+    """
     assert endaq.device.isRecorder(path, strict=False)
+
+
+def test_identification_fail():
+    """ Test a non-recorder path to verify it isn't misidentified.
+    """
+    # Using the test file's directory because it's handy.
+    assert not endaq.device.isRecorder(os.path.dirname(__file__))
 
 
 @pytest.mark.parametrize("path", RECORDER_PATHS)
 def test_basic_instantiation(path):
+    """ Basic test of recorder instantiation. All test 'fake recorders'
+        should instantiate `Recorder` subclasses.
+    """
     endaq.device.RECORDERS.clear()  # Clear any cached devices, just to be safe
     dev = endaq.device.getRecorder(path, strict=False)
     assert dev.partNumber == os.path.basename(path)
-


### PR DESCRIPTION
The definitions of all paths to files on the device have been moved to attributes of `Recorder`. This is to make it easier to modify if the paths change, or become case-sensitive.

Several very basic unit tests that use files on the device were added. These also set things up for additional tests.

Adding @pscheidler as a reviewer because we discussed case sensitivity in filenames. This is mainly just to point out the PR to you; your review can be cursory.