### PR TITLE
Added TargetProcessor, FWRevString, UpdateNotes, and FutureElements

### DIFF
--- a/endaq/device/schemata/flash_package.xml
+++ b/endaq/device/schemata/flash_package.xml
@@ -39,7 +39,7 @@
     <StringElement name="TargetProcessor" id="0xF6" multiple="0" mandatory="1"> Processor the attached update is intended for. Values include "EFM32GG11B820F2048GL120", "STM32U585AII6", or "ANY" for non-firmware updates</StringElement>
     <StringElement name="FWRevString" id="0xF7" multiple="0" mandatory="0"> Human readable firmware revision</StringElement>
     <StringElement name="UpdateNotes" id="0xF8" multiple="0" mandatory="0"> Human readable notes regarding the update</StringElement>
-    <MasterElement name="FutureElements" global="1" id="0xE0" multiple="0" mandatory="0">The device may skip elements inside FutureElements without stopping the update. Any other unrecognized elements will kill the firmware update.
+    <MasterElement name="NonCriticalElements" global="1" id="0xE0" multiple="0" mandatory="0">The device may skip elements inside NonCriticalElements without stopping the update. Any other unrecognized elements will kill the firmware update.
     </MasterElement> <!-- UpdatePkg -->
 
 </MasterElement> <!-- UpdatePkg -->

--- a/endaq/device/schemata/flash_package.xml
+++ b/endaq/device/schemata/flash_package.xml
@@ -36,6 +36,12 @@
     <UIntegerElement name="MinFWRev" id="0xF3" multiple="0" mandatory="0"> Minimum firmware version that can receive this update (in case of interface changes)</UIntegerElement>
 	<IntegerElement name="KeySlot" id="0xF4" multiple="0" mandatory="1"> AES Key slot used to encrypt payload (-1 for unencrypted payload)</IntegerElement>
 	<IntegerElement name="PayloadLen" id="0xF5" multiple="0" mandatory="1"> Length of following encrypted payload  of the following format: 1 or more of (uint16 byte offset || uint16 length || [length] bytes of binary data to flash)</IntegerElement>
+    <StringElement name="TargetProcessor" id="0xF6" multiple="0" mandatory="1"> Processor the attached update is intended for. Values include "EFM32GG11B820F2048GL120", "STM32U585AII6", or "ANY" for non-firmware updates</StringElement>
+    <StringElement name="FWRevString" id="0xF7" multiple="0" mandatory="0"> Human readable firmware revision</StringElement>
+    <StringElement name="UpdateNotes" id="0xF8" multiple="0" mandatory="0"> Human readable notes regarding the update</StringElement>
+    <MasterElement name="FutureElements" global="1" id="0xE0" multiple="0" mandatory="0">The device may skip elements inside FutureElements without stopping the update. Any other unrecognized elements will kill the firmware update.
+    </MasterElement> <!-- UpdatePkg -->
+
 </MasterElement> <!-- UpdatePkg -->
 
 <!-- Not part of the schema officially, but there is a binary blob appended to the end of this "header" that carries the payload described by the tags above -->


### PR DESCRIPTION
`TargetProcessor` is definitely needed. Other elements are nice to have but I want to get them in because right now the FW stops an update if it sees an unrecognized element.