### PR TITLE
Feature/legacy config

### DIFF
--- a/endaq/device/__init__.py
+++ b/endaq/device/__init__.py
@@ -145,8 +145,8 @@ def getDevices(paths: Optional[List[Filename]] = None,
             have changed (e.g., their drive letter or mount point changed
             after a device reset).
         :param strict: If `False`, only the directory structure is used
-            to identify a recorder. If `True`, non-FAT file systems will
-            be automatically rejected.
+            to identify a recorder. If `True`, non-FAT file systems and
+            non-removable media will be automatically rejected.
         :return: A list of instances of `Recorder` subclasses.
     """
     global RECORDERS

--- a/endaq/device/command_interfaces.py
+++ b/endaq/device/command_interfaces.py
@@ -647,7 +647,7 @@ class CommandInterface:
                 not indicate that the updates were successfully applied.
         """
         if isinstance(firmware, str) and firmware.lower().endswith('.bin'):
-            if self.device.getInfo('KeyRev'):
+            if self.device.getInfo('KeyRev', 0):
                 raise ValueError(
                     'Cannot apply unencrypted firmware (*.bin) to device '
                     'with encryption; use *.pkg version if available.')

--- a/endaq/device/config.py
+++ b/endaq/device/config.py
@@ -194,8 +194,9 @@ class ConfigItem:
         if interface and self.vtype:
             self.dtype = interface._schema[self.vtype].dtype
 
-        self._changed = False
-        self._originalValue = self.value
+        self._fromFile = False  # Indicates value was read from file, set during load
+        self._changed = False  # Overrides item value change detection
+        self._originalValue = self.value  # Part of change detection
 
 
     def parseOptions(self, options: list) -> dict:
@@ -369,7 +370,7 @@ class ConfigItem:
             :return: A 2 item dictionary if `value` is not `None`, else
                 `None`.
         """
-        if self.value is not None and (defaults or self.configValue != self._default):
+        if self.value is not None and ((defaults or self.configValue != self._default) or self._fromFile):
             return {'ConfigID': self.configId,
                     self.vtype: self.configValue}
         return None
@@ -664,6 +665,7 @@ class ConfigInterface:
                 if k in self._items:
                     self._items[k].configValue = v[1]
                     self._items[k].changed = False
+                    self._items[k]._fromFile = True
                 else:
                     self.unknownConfig[k] = v
 

--- a/endaq/device/macos.py
+++ b/endaq/device/macos.py
@@ -1,30 +1,20 @@
 """
-MacOS-specific functions; primarily filesystem-related.
+MacOS-specific functions; primarily filesystem-related. The parent package
+imports the appropriate version for the host OS.
 
 TODO: THIS NEEDS TO BE REFACTORED. BASE ON NEXT RELEASE VERSION OF `linux.py`
 """
 
+__all__ = ('deviceChanged', 'getDeviceList', 'getBlockSize', 'getFreeSpace',
+           'getDriveInfo', 'readRecorderClock', 'readUncachedFile')
+
 import os
 
-from .linux import getDriveInfo, readUncachedFile, readRecorderClock
+from .linux import getBlockSize, getDriveInfo, readUncachedFile, readRecorderClock
 
 #===============================================================================
 #
 #===============================================================================
-
-
-# def getDriveInfo(dev):
-#     # XXX: Total hack.
-#     return Drive(dev, os.path.basename(dev), None, 'fat', None)
-#
-#
-# def readRecorderClock(clockfile):
-#     t0 = time.time()
-#     f = open(clockfile, 'rb', 0)
-#     t = f.read(8)
-#     t1 = (time.time() + t0) / 2
-#     f.close()
-#     return t1, t
 
 
 def getDeviceList(types, paths=None):
@@ -86,12 +76,3 @@ def getFreeSpace(path):
     # TODO: Make sure this actually works. Should work on all POSIX OSes.
     st = os.statvfs(path)
     return st.f_bavail * st.f_frsize
-
-
-def getBlockSize(path):
-    """ Return the bytes per sector and sectors per cluster of a drive.
-
-        :param path: The path to the drive to check. Can be a subdirectory.
-        :return: A tuple containing the bytes/sector and sectors/cluster.
-    """
-    raise NotImplementedError("XXX: IMPLEMENT macos.getBlockSize()!")


### PR DESCRIPTION
This PR ostensibly fixes the legacy config format, but also includes changes and fixes made to work with the configuration GUI (a separate project).

* The new/legacy config format has been made more general, with a list of supported config versions (currently just 1 and 2: old and new).
* `ConfigItem.value` defaults to None, preventing problems with the GUI incorrectly enabling items.
* Fixes `ConfigItem.dtype` to use the *Field data type instead of the default value (which is the config units, not display units, and may not match).
* Lots of little fixes and docstring changes.