### PR TITLE
Release/1.0.0

### DIFF
--- a/docs/endaq/quickstart.rst
+++ b/docs/endaq/quickstart.rst
@@ -2,6 +2,8 @@
 ``endaq.device`` Concepts and Quick Start Guide
 ===============================================
 
+Here are some concept summaries and common usage examples to help you get started with ``endaq.device``.
+
 .. note::
   This documentation is in very early development.
 
@@ -19,11 +21,55 @@ A ``endaq.device`` "Hello World":
    >>> endaq.device.getDevices()
    [<EndaqS S3-E25D40 "Example S3" SN:S0009468 (D:\)>]
    >>> dev = _[0]
+
+Accessing basic recorder properties
+-----------------------------------
+
+Most common properties are read-only attributes of :py:class:`endaq.device.Recorder`.
+
+.. code-block:: python
+
+   >>> dev.name
+   'Example S3'
+   >>> dev.serial
+   'S0009468'
+   >>> dev.hardwareVersion
+   '2.0'
+
+Some :py:class:`endaq.device.Recorder` properties are identical to those of an
+`idelib.Dataset <https://mide-technology-idelib.readthedocs-hosted.com/en/latest/idelib/dataset.html#idelib.dataset.Dataset>`_
+(an imported recording file). These include:
+
+* ``sensors``: The device's sensors, a dictionary of `idelib.Sensor` objects.
+* ``channels``: The device's Channels, a dictionary of `idelib.Channel` objects.
+* ``transforms``: The device's data conversion and calibration polynomials, as `idelib.transforms.Transform` objects.
+
+.. code-block:: python
+
    >>> dev.channels
    {8: <Channel 8 '25g PE Acceleration': Acceleration (g)>, 80: <Channel 80 '40g DC Acceleration': Acceleration (g)>, 36: <Channel 36 'Pressure/Temperature': Pressure (Pa), Temperature (°C)>, 65: <Channel 65 'Absolute Orientation': Quaternion (q)>, 70: <Channel 70 'Relative Orientation': Quaternion (q)>, 47: <Channel 47 'Rotation': Rotation (dps)>, 59: <Channel 59 'Control Pad Pressure/Temperature/Humidity': Pressure (Pa), Temperature (°C), Relative Humidity (RH)>, 76: <Channel 76 'Light Sensor': Light (Ill), Light (Index)>}
 
+Configuration
+-------------
+
+Configuration is done via the `configuration interface <config_control.html#configuration>`_.
+
+.. code-block:: python
+
+   >>> dev.config.enableChannel(dev.channels[8][0], True)
+   >>> dev.config.setSampleRate(dev.channels[8], 3600)
+
+Control
+-------
+
+Device control is done via the `command interface <config_control.html#control>`_.
+
+.. code-block:: python
+
+   >>> dev.command.startRecording()
+
 Virtual devices
----------------
+===============
 An enDAQ ``.IDE`` recording file can be used to create a 'virtual' version
 of the recorder that created it. This provides an easy way to retrieve
 information about the device and how it was configured.
@@ -33,13 +79,4 @@ information about the device and how it was configured.
   >>> from idelib.importer import openFile
   >>> with openFile('test.ide') as doc:
   ...     virtual_dev = endaq.device.fromRecording(doc)
-
-Accessing basic recorder properties
-===================================
-Some `endaq.device.Recorder` properties are identical to those of an
-`idelib.Dataset` (an imported recording file). These include:
-
-* ``sensors``: The device's sensors, a dictionary of `idelib.Sensor` objects.
-* ``channels``: The device's Channels, a dictionary of `idelib.Channel` objects.
-* ``transforms``: The device's data conversion and calibration polynomials, as `idelib.transforms.Transform` objects.
 

--- a/endaq/device/command_interfaces.py
+++ b/endaq/device/command_interfaces.py
@@ -848,7 +848,7 @@ class CommandInterface:
 
         cmd = {'EBMLCommand': {'WiFiScan': None}}
 
-        response = self._sendCommand(cmd, True, timeout, interval, callback)
+        response = self._sendCommand(cmd, response=True, timeout=timeout, interval=interval, callback=callback)
 
         if response is None:
             return None

--- a/endaq/device/command_interfaces.py
+++ b/endaq/device/command_interfaces.py
@@ -989,6 +989,13 @@ class SerialCommandInterface(CommandInterface):
         if device.isVirtual:
             return False
 
+        # If the DEVINFO explicitly indicates a serial command interface,
+        # trust it.
+        if device.getInfo('SerialCommandInterface') is not None:
+            return True
+
+        # Some older released FW that supports the serial command interface
+        # does not indicate so in the DEVINFO; find the port instead.
         return bool(cls.findSerialPort(device))
 
 
@@ -1616,9 +1623,11 @@ class FileCommandInterface(CommandInterface):
         if 'SlamStick' in type(device).__name__ and not device.canRecord:
             return False
 
-        # All current, 'real' devices should support the COMMAND file
-        # (but don't check; a user could have deleted it accidentally)
-        return True
+        # Newer firmware will explicitly indicate in DEVINFO if the device
+        # supports the COMMAND file interface. All EFM32 devices should
+        # support it, but their FW may not report it in DEVINFO, so assume
+        # the absence of the `FileCommandInterface` element means 'yes'.
+        return bool(device.getInfo('FileCommandInterface', 1))
 
 
     def _readResponse(self,

--- a/endaq/device/config.py
+++ b/endaq/device/config.py
@@ -913,6 +913,13 @@ class ConfigInterface:
                       enabled: bool = True):
         """ Enable or disable a `Channel` or `SubChannel`.
 
+            Due to the way in which they operate, some sensor's `SubChannels`
+            cannot be individually configured, and changes must be made to
+            the parent `Channel`. The opposite is true for other sensors -
+            primarily the analog ones - which can only be configured at the
+            `SubChannel` level. Attempting to configure at the wrong 'level'
+            will raise a ``ConfigError``.
+
             :param channel: The channel or subchannel to enable/disable.
             :param enabled: `True` to enable the channel/subchannel recording.
         """
@@ -956,11 +963,17 @@ class ConfigInterface:
 
     def isEnabled(self,
                   channel: Union[Channel, SubChannel]) -> bool:
-        """
-        Is the `Channel` or `SubChannel` enabled?
+        """ Is the `Channel` or `SubChannel` enabled?
 
-        :param channel: The `Channel` or `SubChannel` to check.
-        :return: `True` if configured to record.
+            Due to the way in which they operate, some sensor's `SubChannels`
+            cannot be individually configured, and changes must be made to
+            the parent `Channel`. The opposite is true for other sensors -
+            primarily the analog ones - which can only be configured at the
+            `SubChannel` level. Attempting to configure at the wrong 'level'
+            will raise a ``ConfigError``.
+
+            :param channel: The `Channel` or `SubChannel` to check.
+            :return: `True` if configured to record.
         """
         configId = self._getChannelConfigId(0x010000, channel)
         enItem = self._getitem(configId)
@@ -1106,11 +1119,12 @@ class ConfigInterface:
                       channel: Channel) -> float:
         """ Get the sample rate of a `Channel`.
 
-            :param channel: The `Channel` or `SubChannel` to get.
+            :param channel: The `Channel` to get.
             :return: The sampling rate, in hertz.
         """
         configId = self._encodeChannel(channel) | 0x020000
-        return self._getitem(configId).value
+        item = self._getitem(configId)
+        return item.value if item.value is not None else item.default
 
 
     def getTriggers(self) -> List[ConfigItem]:

--- a/endaq/device/endaq.py
+++ b/endaq/device/endaq.py
@@ -75,26 +75,29 @@ class EndaqW(EndaqS):
                 timeout: int = 10,
                 interval: float = 1.25,
                 callback: Optional[Callable] = None):
-        """ Gives the commands to set the devices Wi-Fi (if present).
+        """ Configure all known Wi-Fi access points. Applicable only
+            to devices with Wi-Fi hardware. The data is in the form of a
+            list of dictionaries with the following keys:
+
+            * ``"SSID"``: The Wi-Fi access point name (string)
+            * ``"Password"``: The access point's password (string, optional)
+            * ``"Selected"``: 1 if the device should use this AP, 0 if not
+
+            Note that devices may not support configuring multiple Wi-Fi AP.
+            In most cases, only one should be specified, and it should be
+            marked as selected.
+
+            Note: This method is deprecated. Use `recorder.command.setWiFi()`
+            instead.
 
             :param wifi_data: The information about the Wi-Fi networks to be
-                set on the device.  Specifically, it's a list of dictionaries,
-                where each element in the list corresponds to one of the Wi-Fi
-                networks to be set.  The following are two examples of this:
-                [{'SSID': 'office_wifi', 'Selected': 1, 'Password': 'pass123'}]
-                or
-                [{'SSID': 'ssid_1', 'Selected': 1, 'Password': 'pass_1'},
-                 {'SSID': 'ssid_2', 'Selected': 0},
-                 {'SSID': 'ssid_1', 'Selected': 0, 'Password': 'pass_3'}]
+                set on the device.
             :param timeout: Time (in seconds) to wait for a response before
-                raising a `DeviceTimeout` exception.
+                raising a :class:`~.endaq.device.DeviceTimeout` exception.
             :param interval: Time (in seconds) between checks for a response.
             :param callback: A function to call each response-checking cycle.
                 If the callback returns `True`, the wait for a response will be
-                cancelled. The callback function should require no arguments.
-
-            :raise DeviceTimeout: Raised if 'timeout' seconds have gone by
-                without getting a response
+                cancelled. The callback function should take no arguments.
         """
         # FUTURE: Remove EndaqW.setWiFi()
         warnings.warn("Direct control moved to `command` attribute; use "
@@ -123,6 +126,9 @@ class EndaqW(EndaqS):
                   callback: Optional[Callable] = None) -> Union[None, dict]:
         """ Check the current state of the Wi-Fi (if present).
 
+            Note: This method is deprecated. Use `recorder.command.queryWiFi()`
+            instead.
+
             :param timeout: Time (in seconds) to wait for a response before
                 raising a `DeviceTimeout` exception.
             :param interval: Time (in seconds) between checks for a response.
@@ -132,9 +138,6 @@ class EndaqW(EndaqS):
             :return: None if no information was recieved, else it will return
                 the information from the ``QueryWiFiResponse`` command (this
                 return statement is not used anywhere)
-
-            :raise DeviceTimeout: Raised if 'timeout' seconds have gone by
-                without getting a response
         """
         # FUTURE: Remove EndaqW.queryWifi()
         warnings.warn("Direct control moved to `command` attribute; use "
@@ -151,28 +154,31 @@ class EndaqW(EndaqS):
     def scanWifi(self, timeout: int = 10,
                  interval: float = .25,
                  callback: Optional[Callable] = None) -> Union[None, list]:
-        """ Initiate a scan for Wi-Fi access points (APs).
+        """ Initiate a scan for Wi-Fi access points (APs). Applicable only
+            to devices with Wi-Fi hardware.
+
+            The resluts are returned as a list of dictionaries, one for each
+            access point, with keys:
+
+            * ``SSID`` (str): The access point name.
+            * ``RSSI`` (int): The AP's signal strength.
+            * ``AuthType`` (int): The authentication (security) type.
+              Currently, this is either 0 (no authentication) or 1
+              (any authentication).
+            * ``Known`` (bool): Is this access point known (i.e. has
+              a stored password on the device)?
+            * ``Selected`` (bool): Is this the currently selected AP?
+
+            Note: This method is deprecated. Use `recorder.command.scanWiFi()`
+            instead.
 
             :param timeout: Time (in seconds) to wait for a response before
-                raising a `DeviceTimeout` exception.
+                raising a :class:`~.endaq.device.DeviceTimeout` exception.
             :param interval: Time (in seconds) between checks for a response.
             :param callback: A function to call each response-checking cycle.
                 If the callback returns `True`, the wait for a response will
                 be cancelled. The callback function should take no arguments.
-
-            :return: A list of dictionaries, one for each access point,
-                with keys:
-                - ``SSID`` (str): The access point name.
-                - ``RSSI`` (int): The AP's signal strength.
-                - ``AuthType`` (int): The authentication (security) type.
-                    Currently, this is either 0 (no authentication) or 1
-                    (any authentication).
-                - ``Known`` (bool): Is this access point known (i.e. has
-                    a stored password on the device)?
-                - ``Selected`` (bool): Is this the currently selected AP?
-
-            :raise DeviceTimeout: Raised if 'timeout' seconds have gone by
-                without getting a response
+            :return: A list of dictionaries, described above.
         """
         # FUTURE: Remove EndaqW.scanWifi()
         warnings.warn("Direct control moved to `command` attribute; use "
@@ -192,6 +198,9 @@ class EndaqW(EndaqS):
                     timeout: float = 10,
                     callback: Optional[Callable] = None):
         """ Update the ESP32 firmware.
+
+            Note: This method is deprecated. Use `recorder.command.updateESP32()`
+            instead.
 
             :param firmware: The name of the ESP32 firmware package (.bin).
             :param destination: The name of the firmware package after being

--- a/endaq/device/schemata/mide_manifest.xml
+++ b/endaq/device/schemata/mide_manifest.xml
@@ -142,13 +142,18 @@
         <MasterElement name="DigitalSensorMS8607" id="0x4DA1" mandatory="0" multiple="0" minver="1">Indicates the presence of an MS8607 P/T/H sensor on the I2C1 bus.</MasterElement>
         <MasterElement name="DigitalSensorMS5637" id="0x4DA2" mandatory="0" multiple="0" minver="1">Indicates the presence of an MS5637 pressure sensor on the I2C1 bus.</MasterElement>
         <MasterElement name="DigitalSensorHTU21D" id="0x4DA3" mandatory="0" multiple="0" minver="1">Indicates the presence of an HTU21D humidity sensor on the I2C1 bus.</MasterElement>
+        <MasterElement name="DigitalSensorSHT41" id="0x4DA4" mandatory="0" multiple="0" minver="1">Indicates the presence of a SHT41 temp/hum sensor on an I2C bus. Note software-compatible SHT4x variants provide no way of distinguishing them via the bus, so SHT41, 42, etc. need their own IDs if FW needs to differentiate them.</MasterElement>
+        <MasterElement name="DigitalSensorTMP116_117" id="0x4DA5" mandatory="0" multiple="0" minver="1">Indicates the presence of a TMP116/7 temperature sensor on an I2C bus. Variant (116, 117) can be distinguished via register read.</MasterElement>
+
+
+
 
         <!-- Timing/Sync inputs -->
         <MasterElement name="DigitalSensorIR" id="0x4DB0" mandatory="0" multiple="0" minver="1">Indicates the presence of a digital IR sensor.</MasterElement>
 
         <!-- GPS/Sync inputs -->
         <MasterElement name="DigitalSensorGPS_UART" id="0x4DC0" mandatory="0" multiple="0" minver="1">Indicates the presence of a GPS with full data (location) broken out on UART.</MasterElement>
-        <MasterElement name="DigitalSensorGPS_CAMM8" id="0x4DC1" mandatory="0" multiple="0" minver="1">Indicates the presence of a GPS with full data (location) broken out on UART.
+        <MasterElement name="DigitalSensorGPS_CAMM8" id="0x4DC1" mandatory="0" multiple="0" minver="1">Indicates the presence of a GPS with full data (location) broken out on UART supporting the uBlox protocol.
             <UIntegerElement name="SensorConfig" id="0x4E00" mandatory="0" multiple="0" minver="1">Configuration data for digital sensors. Value varies by hardware.</UIntegerElement>
         </MasterElement>
 

--- a/endaq/device/schemata/mide_manifest.xml
+++ b/endaq/device/schemata/mide_manifest.xml
@@ -128,6 +128,9 @@
         <MasterElement name="DigitalSensorADXL357" id="0x4DD5" mandatory="0" multiple="0" minver="1">Indicates the presence of an ADXL357 accelerometer on the SPI bus.
             <UIntegerElement name="SensorConfig" id="0x4E00" mandatory="0" multiple="0" minver="1">Configuration data for digital sensors. Value varies by hardware.</UIntegerElement>
         </MasterElement>
+        <MasterElement name="DigitalSensorADXL359" id="0x4DD6" mandatory="0" multiple="0" minver="1">Indicates the presence of an ADXL359 accelerometer on the SPI bus.
+            <UIntegerElement name="SensorConfig" id="0x4E00" mandatory="0" multiple="0" minver="1">Configuration data for digital sensors. Value varies by hardware.</UIntegerElement>
+        </MasterElement>
         <MasterElement name="DigitalSensorADXL375" id="0x4D92" mandatory="0" multiple="0" minver="1">Indicates the presence of an ADXL375 accelerometer on the SPI bus.</MasterElement>
         <MasterElement name="DigitalSensorBNO055" id="0x4D93" mandatory="0" multiple="0" minver="1">Indicates the presence of a BNO055 IMU on the I2C0 bus.</MasterElement>
         <MasterElement name="DigitalSensorBHI160" id="0x4D94" mandatory="0" multiple="0" minver="1">Indicates the presence of a Bosch BHI160 IMU on the I2C0 bus.

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ with open('docs/requirements.txt', 'r') as fh:
 
 setuptools.setup(
         name='endaq-device',
-        version='1.0.0b2',
+        version='1.0.0',
         author='Mide Technology',
         author_email='help@mide.com',
         description='Python API for enDAQ data recorders',
@@ -31,10 +31,9 @@ setuptools.setup(
         long_description_content_type='text/markdown',
         url='https://github.com/MideTechnology/endaq-device',
         license='MIT',
-        classifiers=['Development Status :: 4 - Beta',
+        classifiers=['Development Status :: 5 - Production/Stable',
                      'License :: OSI Approved :: MIT License',
                      'Natural Language :: English',
-                     'Programming Language :: Python :: 3.6',
                      'Programming Language :: Python :: 3.7',
                      'Programming Language :: Python :: 3.8',
                      'Programming Language :: Python :: 3.9',


### PR DESCRIPTION
Goodbye, beta! This version has some additions to the schema, documentation updates, and a number of small but necessary fixes.

* Fixed issue configuring devices without preexisting config files.
* Fixed arguments used within `scanWifi()`.
* `getSampleRate()` will now return the default if not set in the config file. 