### PR TITLE
Feature/find serial port fix

### DIFF
--- a/endaq/device/base.py
+++ b/endaq/device/base.py
@@ -324,7 +324,8 @@ class Recorder:
             of a data recorder.
 
             :param dev: The path to the possible recording device (e.g. a
-                mount point under \*NIX, or a drive letter under Windows)
+                mount point under Linux/BSD/etc., or a drive letter under
+                Windows)
             :param strict: If `False`, only the directory structure is used
                 to identify a recorder. If `True`, non-FAT file systems will
                 be automatically rejected.
@@ -1049,7 +1050,7 @@ class Recorder:
                 user-applied calibration (if any).
             :param epoch: If `False` (default), return the calibration date
                 as a Python `datetime.datetime` object. If `False`, return
-                the calibration date as epoch time (i.e., a \*NIX timestamp).
+                the calibration date as epoch time (i.e., a UNIX timestamp).
                 For backwards compatibility with earlier software.
         """
         data = self.getCalibration(user=user)
@@ -1088,7 +1089,7 @@ class Recorder:
                 date of the user-applied calibration (if any).
             :param epoch: If `False` (default), return the expiration date as
                 a Python `datetime.datetime` object. If `False`, return the
-                expiration date as epoch time (i.e., a \*NIX timestamp). For
+                expiration date as epoch time (i.e., a UNIX timestamp). For
                 backwards compatibility with earlier software.
         """
         ce = self._getCalExpiration(self.getCalibration(user=user))

--- a/endaq/device/command_interfaces.py
+++ b/endaq/device/command_interfaces.py
@@ -1014,8 +1014,8 @@ class SerialCommandInterface(CommandInterface):
 
         for p in serial.tools.list_ports.comports():
             # Find valid USB/serial device by vendor/product ID
-            if (p.vid, p.pid) not in cls.USB_IDS:
-                continue
+            # if (p.vid, p.pid) not in cls.USB_IDS:
+            #     continue
             try:
                 sn = int(p.serial_number)
                 if sn == device.serialInt:

--- a/endaq/device/command_interfaces.py
+++ b/endaq/device/command_interfaces.py
@@ -932,7 +932,8 @@ class SerialCommandInterface(CommandInterface):
     """
 
     # USB serial port vendor and product IDs, for finding the right device
-    VID, PID = 0x10C4, 0x0004  # SiLabs USB Serial, e.g. enDAQ recorders
+    USB_IDS = ((0x10C4, 0x0004),  # SiLabs USB Serial, e.g. enDAQ recorders
+               (0x0483, 0x4003))  # STM32 USB Serial, e.g. newer enDAQs
 
     # Default serial port parameters
     SERIAL_PARAMS = dict(baudrate=115200,
@@ -1012,13 +1013,15 @@ class SerialCommandInterface(CommandInterface):
             return None
 
         for p in serial.tools.list_ports.comports():
-            if not (p.vid == cls.VID and p.pid == cls.PID):
+            # Find valid USB/serial device by vendor/product ID
+            if (p.vid, p.pid) not in cls.USB_IDS:
                 continue
             try:
                 sn = int(p.serial_number)
                 if sn == device.serialInt:
                     return p.device
             except ValueError as err:
+                # Probably text in serial number, ignore if so
                 if 'invalid literal' not in str(err).lower():
                     raise
 

--- a/endaq/device/command_interfaces.py
+++ b/endaq/device/command_interfaces.py
@@ -263,7 +263,7 @@ class CommandInterface:
             to a second to run. Not applicable if a specific time is
             provided (i.e. `t` is not `None`).
         :return: The system time (float) and time that was set (integer).
-            Both are \*NIX epoch time (seconds since 1970-01-01T00:00:00).
+            Both are UNIX epoch time (seconds since 1970-01-01T00:00:00).
         """
         raise NotImplementedError
 
@@ -307,7 +307,7 @@ class CommandInterface:
                 fail. Although rare, random filesystem things can potentially
                 cause hiccups.
             :return: The system time (float) and time that was set (integer).
-                Both are \*NIX epoch time (seconds since 1970-01-01T00:00:00).
+                Both are UNIX epoch time (seconds since 1970-01-01T00:00:00).
         """
         if t is not None:
             pause = False
@@ -1017,6 +1017,8 @@ class SerialCommandInterface(CommandInterface):
             # if (p.vid, p.pid) not in cls.USB_IDS:
             #     continue
             try:
+                if not p.serial_number:
+                    continue
                 sn = int(p.serial_number)
                 if sn == device.serialInt:
                     return p.device
@@ -1361,7 +1363,7 @@ class SerialCommandInterface(CommandInterface):
             to a second to run. Not applicable if a specific time is
             provided (i.e. `t` is not `None`).
         :return: The system time (float) and time that was set (integer).
-            Both are \*NIX epoch time (seconds since 1970-01-01T00:00:00).
+            Both are UNIX epoch time (seconds since 1970-01-01T00:00:00).
         """
         if t is None:
             t = time()
@@ -1710,7 +1712,7 @@ class FileCommandInterface(CommandInterface):
             to a second to run. Not applicable if a specific time is
             provided (i.e. `t` is not `None`).
         :return: The system time (float) and time that was set (integer).
-            Both are \*NIX epoch time (seconds since 1970-01-01T00:00:00).
+            Both are UNIX epoch time (seconds since 1970-01-01T00:00:00).
         """
         if t is None:
             t = time()


### PR DESCRIPTION
Fixes an issue finding STM32 serial interfaces; before comparing serial numbers, they were filtered by USB VID/PID, and the STM32s' differ from the EFM32s'.

First, the STM32 VID/PID were added to the valid list. I decided this was too restrictive, requiring a largely unnecessary update if new MCUs are introduced. I think the chances that another USB/serial interface having the same serial number as the user's enDAQ recorder are unlikely enough to not need such filtering.