### PR TITLE
Fix for extraneous data in `syscal` file

### DIFF
--- a/endaq/device/base.py
+++ b/endaq/device/base.py
@@ -925,9 +925,8 @@ class Recorder:
         try:
             with loadSchema("mide_ide.xml").load(calFile) as doc:
                 self._calData = doc.schema.loads(doc.getRaw())
-                calDict = self._calData.dump()
-            self._calibration = calDict.get('CalibrationList')
-        except (FileNotFoundError, AttributeError, KeyError) as err:
+                self._calibration = self._calData[0].dump()
+        except (FileNotFoundError, AttributeError, IndexError) as err:
             logger.debug(f"Possibly-allowed exception when reading {calFile}: {err!r}")
 
         try:


### PR DESCRIPTION
Fixes an issue caused by extraneous data after the `CalibrationList` element in `syscal` files (first spotted in STM32 firmware 03.0.07-BETA). This just makes the parsing a little tidier.