### PR TITLE
Feature/es 535 536 legacy config fixes

### DIFF
--- a/endaq/device/base.py
+++ b/endaq/device/base.py
@@ -773,29 +773,28 @@ class Recorder:
     def getTime(self, epoch=True) -> Union[Tuple[datetime, datetime], Tuple[Epoch, Epoch]]:
         """ Read the date/time from the device.
 
-            Deprecated; use `command.getTime()` instead.
-
             :param epoch: If `True`, return the date/time as integer seconds
                 since the epoch ('Unix time'). If `False`, return a Python
                 `datetime.datetime` object.
             :return: The system time and the device time. Both are UTC.
         """
-        # FUTURE: Remove Recorder.getTime()
-        warnings.warn("Direct control moved to `command` attribute; use "
-                      "recorder.command.getTime()",
-                      DeprecationWarning)
+        if self.isVirtual or not self.path:
+            raise UnsupportedFeature('Virtual devices do not have clocks')
 
-        return self.command.getTime(epoch=epoch)
+        if self.command:
+            return self.command.getTime(epoch=epoch)
+        else:
+            logger.debug('')
+            ci = command_interfaces.FileCommandInterface(self)
+            return ci.getTime(epoch=epoch)
 
 
     def setTime(self,
                 t: Union[Epoch, datetime, struct_time, tuple, None] = None,
-                pause=True,
-                retries=1) -> Epoch:
+                pause: bool = True,
+                retries: int = 1) -> Epoch:
         """ Set a recorder's date/time. A variety of standard time types are
             accepted. Note that the minimum unit of time is the whole second.
-
-            Deprecated; use `command.setTime()` instead.
 
             :param t: The time to write, as either seconds since the epoch
                 (i.e. 'Unix time'), `datetime.datetime` or a UTC
@@ -810,19 +809,21 @@ class Recorder:
                 fail. Random filesystem things can potentially cause hiccups.
             :return: The time that was set, as integer seconds since the epoch.
         """
-        # FUTURE: Remove Recorder.setTime()
-        warnings.warn("Direct control moved to `command` attribute; use "
-                      "recorder.command.setTime()",
-                      DeprecationWarning)
+        if self.isVirtual or not self.path:
+            raise UnsupportedFeature('Virtual devices do not have clocks')
 
-        return self.command.setTime(t=t, pause=pause, retries=retries)
+        if self.command:
+            return self.command.setTime(t=t, pause=pause, retries=retries)
+        else:
+            ci = command_interfaces.FileCommandInterface(self)
+            return ci.setTime(t=t, pause=pause, retries=retries)
 
 
-    def getClockDrift(self, pause=True, retries=1) -> float:
+    def getClockDrift(self,
+                      pause: bool = True,
+                      retries: int =1 ) -> float:
         """ Calculate how far the recorder's clock has drifted from the system
             time.
-
-            Deprecated; use `command.getClockDrift()` instead.
 
             :param pause: If `True` (default), the system waits until a
                 whole-numbered second before reading the device's clock. This
@@ -832,12 +833,14 @@ class Recorder:
                 fail. Random filesystem things can potentially cause hiccups.
             :return: The length of the drift, in seconds.
         """
-        # FUTURE: Remove Recorder.getClockDrift()
-        warnings.warn("Direct control moved to `command` attribute; use "
-                      "recorder.command.getClockDrift()",
-                      DeprecationWarning)
+        if self.isVirtual or not self.path:
+            raise UnsupportedFeature('Virtual devices do not have clocks')
 
-        return self.command.getClockDrift(pause=pause, retries=retries)
+        if self.command:
+            return self.command.getClockDrift(pause=pause, retries=retries)
+        else:
+            ci = command_interfaces.FileCommandInterface(self)
+            return ci.getClockDrift(pause=pause, retries=retries)
 
 
     def _parsePolynomials(self, cal: MasterElement) -> Dict[int, Transform]:

--- a/endaq/device/base.py
+++ b/endaq/device/base.py
@@ -1298,8 +1298,7 @@ class Recorder:
         warnings.warn("Direct control should be done through the 'command' attribute",
                       DeprecationWarning)
 
-        return self.command.startRecording(timeout=timeout,
-                                                     callback=callback)
+        return self.command.startRecording(timeout=timeout, callback=callback)
 
 
     # ===========================================================================

--- a/endaq/device/config.py
+++ b/endaq/device/config.py
@@ -1379,7 +1379,7 @@ class FileConfigInterface(ConfigInterface):
         # Do encoding before opening the file, so it can fail safely and not
         # affect any existing config file.
         config = self._makeConfig(unknown, version=version)
-        configEbml = self._schema.encodes(config, headers=False)
+        configEbml = loadSchema('mide_ide.xml').encodes(config, headers=False)
 
         try:
             util.makeBackup(self.device.configFile)

--- a/endaq/device/config.py
+++ b/endaq/device/config.py
@@ -1294,9 +1294,7 @@ class FileConfigInterface(ConfigInterface):
 
         logger.debug('Writing legacy config file for {!r}'.format(self.device))
         vals = self.getConfigValues(original=False, unknown=unknown)
-        config = legacy.generateLegacyConfig(vals, self.device)
-        return {'RecorderConfigurationList':
-                    {'RecorderConfigurationItem': config}}
+        return legacy.generateLegacyConfig(vals, self.device)
 
 
     def getConfigUI(self) -> Union[Document, MasterElement]:


### PR DESCRIPTION
This fixes two issues with Slam Sticks running ancient firmware: writing config files in the legacy format, and setting the clock on devices without any command interface.