### PR TITLE
Switching serial port to use is_open instead of closed

### DIFF
--- a/endaq/device/command_interfaces.py
+++ b/endaq/device/command_interfaces.py
@@ -1068,7 +1068,7 @@ class SerialCommandInterface(CommandInterface):
                 if reset:
                     self.port.close()
                 else:
-                    if self.port.closed:
+                    if not self.port.is_open:
                         self.port.open()
 
                     # Sanity check. Will fail if the device reset the port
@@ -1114,9 +1114,9 @@ class SerialCommandInterface(CommandInterface):
                 already closed.
         """
         try:
-            if self.port and not self.port.closed:
+            if self.port and self.port.is_open:
                 self.port.close()
-                return self.port.closed
+                return not self.port.is_open
         except (IOError, OSError, serial.SerialException) as err:
             # Disconnected device can cause this.
             logger.debug("Ignoring exception when closing {} (probably okay): "


### PR DESCRIPTION
The [PySerial documentation](https://pyserial.readthedocs.io/en/latest/pyserial_api.html) doesn't mention `closed`, I think it might be an inherited property that always returns false, and I believe that in Python 3.10, calling `port.in_waiting` returns a `TypeError` instead of one of the errors caught, causing the script to crash.
The specific situation I was running into was that when running Python 3.10 on Ubuntu for the tester, endaq.device would crash when it tried to send out a second command. This fixes that.