### PR TITLE
`available` properties, await dismount/remount

### DIFF
--- a/endaq/device/base.py
+++ b/endaq/device/base.py
@@ -176,6 +176,19 @@ class Recorder:
             return False
 
 
+    @property
+    def available(self) -> bool:
+        """ Is the device mounted and available as a drive?
+        """
+        if self.isVirtual or not self.path:
+            return False
+
+        # Two checks, since former is a property that sets latter
+        # and path itself isn't a reliable test in Linux
+        return (os.path.exists(self.path)
+                and os.path.isfile(self.infoFile))
+
+
     def __repr__(self):
         path = self._path or "virtual"
         if self.name:

--- a/endaq/device/config.py
+++ b/endaq/device/config.py
@@ -95,10 +95,10 @@ class ConfigItem:
 
 
     _tagsDisplay = compile("[t.strip() for t in x.split(',')]",
-                          "<ConfigItem._tagDisplay>", "eval")
+                           "<ConfigItem._tagDisplay>", "eval")
 
     _tagsValue = compile("','.join(str(x).strip()) if x else ''",
-                          "<ConfigItem._tagValue>", "eval")
+                         "<ConfigItem._tagValue>", "eval")
 
     @classmethod
     def _generateLabel(cls, configId: int) -> Union[str, None]:
@@ -369,7 +369,7 @@ class ConfigItem:
 
 
     @changed.setter
-    def changed(self, changed: bool) -> bool:
+    def changed(self, changed: bool):
         if not changed:
             self._originalValue = self._value
         self._changed = changed
@@ -506,6 +506,20 @@ class ConfigInterface:
         return ui_defaults.getDefaultConfigUI(device) is not None
 
 
+    @property
+    def available(self) -> bool:
+        """ Is the device currently ready for configuration?
+
+            Note: This is intended for future configuration systems. Since
+            configuration is currently applied via the filesystem, it is
+            functionally the same as `Recorder.available`.
+        """
+        # For now, this is basically the same as the device availability,
+        # but allows for future config interfaces (e.g., remote and/or
+        # wireless, etc.)
+        return self.device.available
+
+
     def parseConfigUI(self,
                       configUi: Union[Document, Element]):
         """ Recursively process CONFIG.UI data to populate the interface's
@@ -554,7 +568,7 @@ class ConfigInterface:
 
     def _parseConfig(self,
                      origConfig: dict,
-                     default: Optional[dict] = None) -> Dict[int, Any]:
+                     default: Optional[dict] = None) -> Union[Dict[int, Any], None]:
         """ Helper method to parse a dictionary of dumped EBML
             ``RecorderConfigurationList`` data into a simple dictionary of
             values keyed by ConfigID. Used internally.
@@ -1007,7 +1021,7 @@ class ConfigInterface:
         return configId
 
 
-    def _getChannel(self, configId: int) -> Union[Channel, SubChannel]:
+    def _getChannel(self, configId: int) -> Union[Channel, SubChannel, None]:
         """ Get the Channel/SubChannel corresponding to a configuration ID.
         """
         ch = configId & 0xFF
@@ -1158,6 +1172,14 @@ class VirtualConfigInterface(ConfigInterface):
         :return: `True` if the device supports the interface.
         """
         return device.isVirtual and super().hasInterface(device)
+
+
+    @property
+    def available(self) -> bool:
+        """ Is the device currently ready for configuration?
+        """
+        # Never!
+        return False
 
 
     def getConfigUI(self) -> Union[Document, MasterElement]:
@@ -1374,7 +1396,7 @@ class FileConfigInterface(ConfigInterface):
                 device supports more than one. Defaults to the latest
                 version supported.
         """
-        if not os.path.exists(self.device.path):
+        if not self.available:
             raise IOError(errno.ENOENT, "Could not find {}; is it connected?"
                           .format(self.device))
 

--- a/endaq/device/hdlc.py
+++ b/endaq/device/hdlc.py
@@ -4,7 +4,7 @@ HDLC encoding and checksum-related code.
 In this application, 'HDLC encoding' amounts to using HDLC escaping and
 break characters.
 """
-from typing import Union
+from typing import ByteString, Union
 
 from logging import getLogger
 logger = getLogger('endaq.device')
@@ -143,7 +143,7 @@ def hdlc_encode(in_payload: Union[bytearray, bytes, str],
     return out_payload
 
 
-def hdlc_decode(in_payload: Union[bytearray, bytes],
+def hdlc_decode(in_payload: ByteString,
                 ignore_crc: bool = False) -> bytearray:
     """ Decode an HDLC-encoded packet into raw data.
 


### PR DESCRIPTION
This addresses issue #54, plus some additional improvements.
* `Recorder.available`, `CommandInterface.available` and `ConfigInterface.available` properties
* Improved `CommandInterface.awaitReboot()`
    * Timeout of `None` will wait indefinitely 
* Added `CommandInterface.awaitRemount()`
* Some docstring and annotation improvements
* Minor formatting cleanup