### PR TITLE
Added URLs to setup, added Python 3.11 to unit test workflow

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        python-version: [3.7, 3.8, 3.9, '3.10']
+        python-version: [3.8, 3.9, '3.10', '3.11']
 
     env:
       OS: ${{ matrix.os }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        python-version: [3.8, 3.9, '3.10', '3.11']
+        python-version: [3.8, 3.9, '3.10', '3.11', '3.12']
 
     env:
       OS: ${{ matrix.os }}

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setuptools.setup(
                      'Programming Language :: Python :: 3.9',
                      'Programming Language :: Python :: 3.10',
                      'Programming Language :: Python :: 3.11',
+                     'Programming Language :: Python :: 3.12',
                      ],
         keywords='endaq configure recorder hardware',
         project_urls={

--- a/setup.py
+++ b/setup.py
@@ -61,8 +61,14 @@ setuptools.setup(
                      'Programming Language :: Python :: 3.8',
                      'Programming Language :: Python :: 3.9',
                      'Programming Language :: Python :: 3.10',
+                     'Programming Language :: Python :: 3.11',
                      ],
         keywords='endaq configure recorder hardware',
+        project_urls={
+            "Bug Tracker": "https://github.com/MideTechnology/endaq-device/issues",
+            "Documentation": "https://mide-technology-endaq-device.readthedocs-hosted.com/en/latest/",
+            "Source Code": "https://github.com/MideTechnology/endaq-device",
+            },
         packages=[
             'endaq.device',
             'endaq.device.ui_defaults',


### PR DESCRIPTION
On next release, the PyPI page should show links to the documentation, the repo, and the repo's issues. This PR also removes Python 3.7 from the unit test workflow, and adds Python 3.11 and 3.12.