### PR TITLE
Release/1.1.0

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        python-version: [3.7, 3.8, 3.9, '3.10']
+        python-version: [3.8, 3.9, '3.10', '3.11', '3.12']
 
     env:
       OS: ${{ matrix.os }}

--- a/docs/endaq/Recorder.rst
+++ b/docs/endaq/Recorder.rst
@@ -1,0 +1,22 @@
+######################
+The ``Recorder`` Class
+######################
+.. default-domain:: py
+.. currentmodule:: endaq.device
+
+:class:`~.Recorder` is the class representing an enDAQ recording device.
+There are several subclasses (:class:`~.endaq.EndaqS`, :class:`~.endaq.EndaqW`,
+and legacy :class:`~.slamstick.SlamStickX`,  :class:`~.slamstick.SlamStickC`,
+and  :class:`~.slamstick.SlamStickS`), but nearly all functionality is
+implemented in :class:`~.Recorder`. Devices that do not have a specific
+subclass associated with their product name will instantiate as :class:`~.Recorder`.
+
+.. note::
+  Some or all of the discrete product-specific subclasses may be deprecated in the near
+  future (the legacy SlamStick classes excluded). Using `isinstance()` to determine
+  :class:`~.Recorder` subclasses is not recommended; consider using the properties
+  :attr:`~.Recorder.partNumber` and :attr:`~.Recorder.productName` instead
+  (see below).
+
+.. autoclass:: endaq.device.base.Recorder
+  :members:

--- a/docs/endaq/finding_devices.rst
+++ b/docs/endaq/finding_devices.rst
@@ -1,0 +1,8 @@
+###############
+Finding Devices
+###############
+.. default-domain:: py
+.. currentmodule:: endaq.device
+
+.. automodule:: endaq.device
+  :members: getDevices, deviceChanged, findDevice, fromRecording, getDeviceList, getRecorder, isRecorder, onRecorder

--- a/docs/endaq/quickstart.rst
+++ b/docs/endaq/quickstart.rst
@@ -20,7 +20,6 @@ A ``endaq.device`` "Hello World":
    >>> import endaq.device
    >>> endaq.device.getDevices()
    [<EndaqS S3-E25D40 "Example S3" SN:S0009468 (D:\)>]
-   >>> dev = _[0]
 
 Accessing basic recorder properties
 -----------------------------------
@@ -29,6 +28,7 @@ Most common properties are read-only attributes of :py:class:`endaq.device.Recor
 
 .. code-block:: python
 
+   >>> dev = endaq.device.getDevices()[0]
    >>> dev.name
    'Example S3'
    >>> dev.serial

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,6 +14,8 @@ also supports legacy SlamStick™ devices (X, C, and S).
    :caption: Contents:
 
    endaq/quickstart
+   endaq/finding_devices
+   endaq/Recorder
    endaq/config_control
    endaq/special_topics
    api_ref

--- a/endaq/device/__init__.py
+++ b/endaq/device/__init__.py
@@ -21,7 +21,7 @@ from .types import Filename, Epoch
 
 from . import schemata
 
-__version__ = "1.0.9a1"
+__version__ = "1.1.0"
 
 __all__ = ('CommandError', 'ConfigError', 'ConfigVersionError',
            'DeviceError', 'DeviceTimeout', 'UnsupportedFeature',

--- a/endaq/device/__init__.py
+++ b/endaq/device/__init__.py
@@ -175,28 +175,48 @@ def getDevices(paths: Optional[List[Filename]] = None,
     return result
 
 
-def findDevice(sn: Union[str, int],
+def findDevice(sn: Optional[Union[str, int]] = None,
+               chipId: Optional[Union[str, int]] = None,
                paths: Optional[List[Filename]] = None,
+               update: bool = False,
                strict: bool = True) -> Union[Recorder, None]:
-    """ Find a specific recorder by serial number.
+    """ Find a specific recorder by serial number or unique chip ID. One or
+        the other must be provided, but not both. Note that early firmware
+        versions do not report the device's chip ID.
 
-        :param sn: The serial number of the recorder to find.
+        :param sn: The serial number of the recorder to find. Cannot be used
+            with `chipId`. It can be an integer or a formatted serial number
+            string (e.g., `12345` or `"S00012345"`).
+        :param chipId: The chip ID of the recorder to find. Cannot be used
+            with `sn`. It can be an integer or a hex string.
         :param paths: A list of specific paths to recording devices.
             Defaults to all found devices (as returned by `getDeviceList()`).
+        :param update: If `True`, update the path of known devices if they
+            have changed (e.g., their drive letter or mount point changed
+            after a device reset).
         :param strict: If `False`, only the directory structure is used
             to identify a recorder. If `True`, non-FAT file systems will
             be automatically rejected.
         :return: An instance of a `Recorder` subclass representing the
-            device with the specified serial number, or `None`.
+            device with the specified serial number or chip ID, or `None`
+            if it cannot be found.
     """
+    if sn and chipId:
+        raise ValueError('Either a serial number or chip ID is required, not both')
+    elif sn is None and chipId is None:
+        raise ValueError('Either a serial number or chip ID is required')
+
     if isinstance(sn, str):
         sn = sn.lstrip(string.ascii_letters+"0")
         if not sn:
             sn = 0
         sn = int(sn)
 
-    for d in getDevices(paths, strict=strict):
-        if d.serialInt == sn:
+    if isinstance(chipId, str):
+        chipId = int(chipId, 16)
+
+    for d in getDevices(paths, update=update, strict=strict):
+        if d.serialInt == sn or d.chipId == chipId:
             return d
 
     return None

--- a/endaq/device/__init__.py
+++ b/endaq/device/__init__.py
@@ -21,7 +21,7 @@ from .types import Filename, Epoch
 
 from . import schemata
 
-__version__ = "1.0.8"
+__version__ = "1.0.9a1"
 
 __all__ = ('CommandError', 'ConfigError', 'ConfigVersionError',
            'DeviceError', 'DeviceTimeout', 'UnsupportedFeature',

--- a/endaq/device/command_interfaces.py
+++ b/endaq/device/command_interfaces.py
@@ -522,6 +522,37 @@ class CommandInterface:
         raise UnsupportedFeature(self, self.ping)
 
 
+    def blink(self,
+              duration: int = 3,
+              priority: int = 0,
+              a: int = 0b00000111,
+              b: int = 0b00000000):
+        """ Blink the device's LEDs. This is intended for identifying a
+            specific recorder when multiple are plugged into one computer.
+            Not supported on all devices.
+
+            Blinking will alternate between patterns `a` and `b` every 0.5
+            seconds, continuing for the specified duration. `a` and `b`
+            are unsigned 8 bit integers, in which each bit represents one
+            of the recorder's LEDs:
+                * Bit 0 (LSB): Red
+                * Bit 1: Green
+                * Bit 2: Blue
+                * Bits 3-7: Reserved for future use.
+
+            :param duration: The total duration (in seconds) of the blinking,
+                maximum 255.
+            :param priority: If 1, the Blink command should take precedence
+                over all other device LED sequences. If 0, the Blink command
+                should not take precedence over Wi-Fi indications including
+                Provisioning, Connecting, and Success/Failure indications,
+                but it should take precedence over battery indications.
+            :param a: LED pattern 'A'.
+            :param b: LED pattern 'B'.
+        """
+        raise UnsupportedFeature(self, self.blink)
+
+
     # =======================================================================
     # Firmware/userpage updating
     #
@@ -1626,6 +1657,37 @@ class SerialCommandInterface(CommandInterface):
             raise CommandError('Ping response did not contain a PingReply')
 
         return response['PingReply']
+
+
+    def blink(self,
+              duration: int = 3,
+              priority: int = 0,
+              a: int = 0b00000111,
+              b: int = 0b00000000):
+        """ Blink the device's LEDs. This is intended for identifying a
+            specific recorder when multiple are plugged into one computer.
+            Not supported on all devices.
+
+            Blinking will alternate between patterns `a` and `b` every 0.5
+            seconds, continuing for the specified duration. `a` and `b`
+            are unsigned 8 bit integers, in which each bit represents one
+            of the recorder's LEDs:
+                * Bit 0 (LSB): Red
+                * Bit 1: Green
+                * Bit 2: Blue
+                * Bits 3-7: Reserved for future use.
+
+            :param duration: The total duration of the blinking, 0-255.
+            :param priority: If 1, the Blink command should take precedence
+                over all other device LED sequences. If 0, the Blink command
+                should not take precedence over Wi-Fi indications including
+                Provisioning, Connecting, and Success/Failure indications,
+                but it should take precedence over battery indications.
+            :param a: LED pattern 'A'.
+            :param b: LED pattern 'B'.
+        """
+        payload = bytearray([val & 0xff for val in (duration, priority, a, b)])
+        self._sendCommand({'EBMLCommand': {'Blink': payload}}, response=False)
 
 
     def getBatteryStatus(self,

--- a/endaq/device/schemata/command-response.xml
+++ b/endaq/device/schemata/command-response.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Schema type="mide.ss.cmd" version="2" readversion="1">
+<Schema type="mide.ss.cmd" version="3" readversion="2">
     <SchemaInfo>
         <Author>Derek Witt</Author>
         <Author>David Randall Stokes</Author>
@@ -148,4 +148,21 @@
         </IntegerElement>
         <UnicodeElement name="DeviceStatusMessage" id="0x5901" multiple="0" mandatory="0">Serial only. Optional code for device status, including error message</UnicodeElement>
     </MasterElement>
+
+<!--
+Attributes: a way to insert an arbitrary key/value into a structure, without revising (and potentially bloating) the
+schema itself. This data is typically non-critical. Strictly speaking, this may be considered an abuse of EBML, but it
+is flexible and moderately clean. This is used in several Mide schemata.
+-->
+<MasterElement name="Attribute" id="0x6110" global="1" multiple="1"> Container For arbitrary name/value attributes, allowing additional data without revising (and bloating) the schema. It should contain exactly one `AttributeName` and one of the value elements.
+    <UnicodeElement name="AttributeName" id="0x612f" multiple="0" mandatory="1"> Attribute name. Should always be child of Attribute. </UnicodeElement>
+    <IntegerElement name="IntAttribute" id="0x6120" multiple="0"> Integer Attribute. Should always be child of Attribute. </IntegerElement>
+    <UIntegerElement name="UIntAttribute" id="0x6121" multiple="0"> Unsigned integer Attribute. Should always be child of Attribute. </UIntegerElement>
+    <FloatElement name="FloatAttribute" id="0x6122" multiple="0"> Floating point Attribute. Should always be child of Attribute. </FloatElement>
+    <StringElement name="StringAttribute" id="0x6123" multiple="0"> ASCII String Attribute. Should always be child of Attribute. </StringElement>
+    <DateElement name="DateAttribute" id="0x6124" multiple="0"> Date Attribute. Should always be child of Attribute. </DateElement>
+    <BinaryElement name="BinaryAttribute" id="0x6125" multiple="0"> Binary Attribute. Should always be child of Attribute. </BinaryElement>
+    <UnicodeElement name="UnicodeAttribute" id="0x6126" multiple="0"> Unicode String Attribute. Should always be child of Attribute. </UnicodeElement>
+</MasterElement>
+
 </Schema>

--- a/endaq/device/schemata/command-response.xml
+++ b/endaq/device/schemata/command-response.xml
@@ -81,7 +81,8 @@
         <BinaryElement name="SetClock" id="0x5510" multiple="0" mandatory="0">Serial only. Set the real time clock. Expects a 10 byte value. Comparable to writing to the CLOCK file.</BinaryElement>
         <MasterElement name="GetClock" id="0x5500" multiple="0" mandatory="0">Serial only. Request RTC clock time. Comparable to reading the CLOCK file.</MasterElement>
         <MasterElement name="GetBattery" id="0x5600" multiple="0" mandatory="0">Serial only. Request the battery state.</MasterElement>
-        <BinaryElement name="SendPing" id="0x5700" multiple="0" mandatory="0">Serial only. Request the device echo the enclosed data.</BinaryElement>		
+        <BinaryElement name="SendPing" id="0x5700" multiple="0" mandatory="0">Serial only. Request the device echo the enclosed data.</BinaryElement>
+        <BinaryElement name="Blink" id="0x5800" multiple="0" mandatory="0">Serial only. Blinks LEDs on device for recognition purposes</BinaryElement>
     </MasterElement>
 
     <MasterElement name="EBMLResponse" id="0x86" multiple="0" mandatory="0">Response payload to above EBML command payload. Not all commands generate a response

--- a/endaq/device/schemata/flash_package.xml
+++ b/endaq/device/schemata/flash_package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Schema type="mide.ss.fwpkg" version="2" readversion="2">
+<Schema type="mide.ss.fwpkg" version="3" readversion="2">
     <SchemaInfo>
         <Author>Derek Witt</Author>
         <Description>Metadata and packing format for encrypted update packages</Description>
@@ -45,5 +45,21 @@
 </MasterElement> <!-- UpdatePkg -->
 
 <!-- Not part of the schema officially, but there is a binary blob appended to the end of this "header" that carries the payload described by the tags above -->
+
+<!--
+Attributes: a way to insert an arbitrary key/value into a structure, without revising (and potentially bloating) the
+schema itself. This data is typically non-critical. Strictly speaking, this may be considered an abuse of EBML, but it
+is flexible and moderately clean. This is used in several Mide schemata.
+-->
+<MasterElement name="Attribute" id="0x6110" global="1" multiple="1"> Container For arbitrary name/value attributes, allowing additional data without revising (and bloating) the schema. It should contain exactly one `AttributeName` and one of the value elements.
+    <UnicodeElement name="AttributeName" id="0x612f" multiple="0" mandatory="1"> Attribute name. Should always be child of Attribute. </UnicodeElement>
+    <IntegerElement name="IntAttribute" id="0x6120" multiple="0"> Integer Attribute. Should always be child of Attribute. </IntegerElement>
+    <UIntegerElement name="UIntAttribute" id="0x6121" multiple="0"> Unsigned integer Attribute. Should always be child of Attribute. </UIntegerElement>
+    <FloatElement name="FloatAttribute" id="0x6122" multiple="0"> Floating point Attribute. Should always be child of Attribute. </FloatElement>
+    <StringElement name="StringAttribute" id="0x6123" multiple="0"> ASCII String Attribute. Should always be child of Attribute. </StringElement>
+    <DateElement name="DateAttribute" id="0x6124" multiple="0"> Date Attribute. Should always be child of Attribute. </DateElement>
+    <BinaryElement name="BinaryAttribute" id="0x6125" multiple="0"> Binary Attribute. Should always be child of Attribute. </BinaryElement>
+    <UnicodeElement name="UnicodeAttribute" id="0x6126" multiple="0"> Unicode String Attribute. Should always be child of Attribute. </UnicodeElement>
+</MasterElement>
 
 </Schema>

--- a/endaq/device/schemata/mide_config_ui.xml
+++ b/endaq/device/schemata/mide_config_ui.xml
@@ -788,15 +788,15 @@ Attributes: a way to insert an arbitrary key/value into a structure, without rev
 schema itself. This data is typically non-critical. Strictly speaking, this may be considered an abuse of EBML, but it
 is flexible and moderately clean. This is used in several Mide schemata.
 -->
-<MasterElement name="Attribute" global="1" id="0x6110" multiple="1" minver="2"> Container For arbitrary name/value attributes, allowing additional data without revising (and bloating) the schema. All of these elements are level -1, allowing an AttributeList to occur at any level, but should always be used at the relative levels implied below.
-    <UnicodeElement name="AttributeName" id="0x612f" multiple="0" minver="2"> Attribute name. Should always be child of Atrribute. </UnicodeElement>
-    <IntegerElement name="IntAttribute" id="0x6120" multiple="0" minver="2"> Integer Attribute. Should always be child of Atrribute. </IntegerElement>
-    <UIntegerElement name="UIntAttribute" id="0x6121" multiple="0" minver="2"> Unsigned integer Attribute. Should always be child of Atrribute. </UIntegerElement>
-    <FloatElement name="FloatAttribute" id="0x6122" multiple="0" minver="2"> Floating point Attribute. Should always be child of Atrribute. </FloatElement>
-    <StringElement name="StringAttribute" id="0x6123" multiple="0" minver="2"> ASCII String Attribute. Should always be child of Atrribute. </StringElement>
-    <DateElement name="DateAttribute" id="0x6124" multiple="0" minver="2"> Date Attribute. Should always be child of Atrribute. </DateElement>
-    <BinaryElement name="BinaryAttribute" id="0x6125" multiple="0" minver="2"> Binary Attribute. Should always be child of Atrribute. </BinaryElement>
-    <UnicodeElement name="UnicodeAttribute" id="0x6126" multiple="0" minver="2"> ASCII String Attribute. Should always be child of Atrribute. </UnicodeElement>
+<MasterElement name="Attribute" id="0x6110" global="1" multiple="1"> Container For arbitrary name/value attributes, allowing additional data without revising (and bloating) the schema. It should contain exactly one `AttributeName` and one of the value elements.
+    <UnicodeElement name="AttributeName" id="0x612f" multiple="0" mandatory="1"> Attribute name. Should always be child of Attribute. </UnicodeElement>
+    <IntegerElement name="IntAttribute" id="0x6120" multiple="0"> Integer Attribute. Should always be child of Attribute. </IntegerElement>
+    <UIntegerElement name="UIntAttribute" id="0x6121" multiple="0"> Unsigned integer Attribute. Should always be child of Attribute. </UIntegerElement>
+    <FloatElement name="FloatAttribute" id="0x6122" multiple="0"> Floating point Attribute. Should always be child of Attribute. </FloatElement>
+    <StringElement name="StringAttribute" id="0x6123" multiple="0"> ASCII String Attribute. Should always be child of Attribute. </StringElement>
+    <DateElement name="DateAttribute" id="0x6124" multiple="0"> Date Attribute. Should always be child of Attribute. </DateElement>
+    <BinaryElement name="BinaryAttribute" id="0x6125" multiple="0"> Binary Attribute. Should always be child of Attribute. </BinaryElement>
+    <UnicodeElement name="UnicodeAttribute" id="0x6126" multiple="0"> Unicode String Attribute. Should always be child of Attribute. </UnicodeElement>
 </MasterElement>
 
 </Schema>

--- a/endaq/device/schemata/mide_manifest.xml
+++ b/endaq/device/schemata/mide_manifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Schema type="mide" version="2" readversion="2">
+<Schema type="mide" version="3" readversion="2">
   <!-- Base EBML elements. Required. -->
   <MasterElement name="EBML" id="0x1A45DFA3" mandatory="1" multiple="0" minver="1">Set the EBML characteristics of the data to follow. Each EBML document has to start with this.
       <UIntegerElement name="EBMLVersion" id="0x4286" multiple="0" mandatory="1" default="1" minver="1">The version of EBML parser used to create the file.</UIntegerElement>
@@ -183,4 +183,21 @@
         </MasterElement>
 
 </MasterElement>
+
+<!--
+Attributes: a way to insert an arbitrary key/value into a structure, without revising (and potentially bloating) the
+schema itself. This data is typically non-critical. Strictly speaking, this may be considered an abuse of EBML, but it
+is flexible and moderately clean. This is used in several Mide schemata.
+-->
+<MasterElement name="Attribute" id="0x6110" global="1" multiple="1"> Container For arbitrary name/value attributes, allowing additional data without revising (and bloating) the schema. It should contain exactly one `AttributeName` and one of the value elements.
+    <UnicodeElement name="AttributeName" id="0x612f" multiple="0" mandatory="1"> Attribute name. Should always be child of Attribute. </UnicodeElement>
+    <IntegerElement name="IntAttribute" id="0x6120" multiple="0"> Integer Attribute. Should always be child of Attribute. </IntegerElement>
+    <UIntegerElement name="UIntAttribute" id="0x6121" multiple="0"> Unsigned integer Attribute. Should always be child of Attribute. </UIntegerElement>
+    <FloatElement name="FloatAttribute" id="0x6122" multiple="0"> Floating point Attribute. Should always be child of Attribute. </FloatElement>
+    <StringElement name="StringAttribute" id="0x6123" multiple="0"> ASCII String Attribute. Should always be child of Attribute. </StringElement>
+    <DateElement name="DateAttribute" id="0x6124" multiple="0"> Date Attribute. Should always be child of Attribute. </DateElement>
+    <BinaryElement name="BinaryAttribute" id="0x6125" multiple="0"> Binary Attribute. Should always be child of Attribute. </BinaryElement>
+    <UnicodeElement name="UnicodeAttribute" id="0x6126" multiple="0"> Unicode String Attribute. Should always be child of Attribute. </UnicodeElement>
+</MasterElement>
+
 </Schema>

--- a/setup.py
+++ b/setup.py
@@ -61,8 +61,15 @@ setuptools.setup(
                      'Programming Language :: Python :: 3.8',
                      'Programming Language :: Python :: 3.9',
                      'Programming Language :: Python :: 3.10',
+                     'Programming Language :: Python :: 3.11',
+                     'Programming Language :: Python :: 3.12',
                      ],
         keywords='endaq configure recorder hardware',
+        project_urls={
+            "Bug Tracker": "https://github.com/MideTechnology/endaq-device/issues",
+            "Documentation": "https://mide-technology-endaq-device.readthedocs-hosted.com/en/latest/",
+            "Source Code": "https://github.com/MideTechnology/endaq-device",
+            },
         packages=[
             'endaq.device',
             'endaq.device.ui_defaults',


### PR DESCRIPTION
* Several `CommandInterface` additions and changes were made. The changes may create minor incompatibilities with existing code that uses `Recorder.command`.
  * The 'timeout' behavior for commands has been made more consistent. The `SerialCommandInterface` attribute `timeout` is now exclusively the low-level serial timeout, and is no longer the default timeout for some commands.
  * Commands that do not require a response will return a response if one is received. These commands will still return `None` if no response is received before timing out.
  * Added the `blink()` command, intended for indicating specific devices when multiple recorders are plugged in. Note that the current firmware does not support the command, and only devices with a `SerialCommandInterface` will accept it.
* `endaq.device.findDevice()` now has the keyword argument `chipId` for getting an attached recording device by its unique processor ID.
* Documentation has been expanded and improved.