### PR TITLE
Release/1.1.1

### DIFF
--- a/docs/endaq/quickstart.rst
+++ b/docs/endaq/quickstart.rst
@@ -20,7 +20,6 @@ A ``endaq.device`` "Hello World":
    >>> import endaq.device
    >>> endaq.device.getDevices()
    [<EndaqS S3-E25D40 "Example S3" SN:S0009468 (D:\)>]
-   >>> dev = _[0]
 
 Accessing basic recorder properties
 -----------------------------------
@@ -29,6 +28,7 @@ Most common properties are read-only attributes of :py:class:`endaq.device.Recor
 
 .. code-block:: python
 
+   >>> dev = endaq.device.getDevices()[0]
    >>> dev.name
    'Example S3'
    >>> dev.serial

--- a/endaq/device/__init__.py
+++ b/endaq/device/__init__.py
@@ -21,7 +21,7 @@ from .types import Drive, Filename, Epoch
 
 from . import schemata
 
-__version__ = "1.1.1b1"
+__version__ = "1.1.1"
 
 __all__ = ('CommandError', 'ConfigError', 'ConfigVersionError',
            'DeviceError', 'DeviceTimeout', 'UnsupportedFeature',

--- a/endaq/device/__init__.py
+++ b/endaq/device/__init__.py
@@ -21,7 +21,7 @@ from .types import Filename, Epoch
 
 from . import schemata
 
-__version__ = "1.0.8"
+__version__ = "1.0.9a1"
 
 __all__ = ('CommandError', 'ConfigError', 'ConfigVersionError',
            'DeviceError', 'DeviceTimeout', 'UnsupportedFeature',

--- a/endaq/device/__init__.py
+++ b/endaq/device/__init__.py
@@ -21,7 +21,7 @@ from .types import Drive, Filename, Epoch
 
 from . import schemata
 
-__version__ = "1.1.0"
+__version__ = "1.1.1b1"
 
 __all__ = ('CommandError', 'ConfigError', 'ConfigVersionError',
            'DeviceError', 'DeviceTimeout', 'UnsupportedFeature',

--- a/endaq/device/command_interfaces.py
+++ b/endaq/device/command_interfaces.py
@@ -541,7 +541,9 @@ class CommandInterface:
                 * Bits 3-7: Reserved for future use.
 
             :param duration: The total duration (in seconds) of the blinking,
-                maximum 255.
+                maximum 255. 0 will blink without time limit, stopping when
+                the device is disconnected from USB, or when a recording is
+                started (trigger or button press).
             :param priority: If 1, the Blink command should take precedence
                 over all other device LED sequences. If 0, the Blink command
                 should not take precedence over Wi-Fi indications including

--- a/endaq/device/command_interfaces.py
+++ b/endaq/device/command_interfaces.py
@@ -1008,7 +1008,7 @@ class CommandInterface:
         payload = {}
 
         cmd = {'EBMLCommand': {'LegacyESP': payload}}
-        return self._sendCommand(cmd, timeout=timeout, callback=callback)
+        return self._runSimpleCommand(cmd, timeout=timeout, callback=callback)
 
 
     def getNetworkStatus(self,


### PR DESCRIPTION
* Improved thread safety in `CommandInterface` methods that involve sending multiple commands to the device.
* Command callback functions checked more consistently.
* Added `wait` parameter to `CommandInterface.setAP()`, which will cause the method to verify it has connected to the Wi-Fi access point before returning.
* `CommandInterface.updateESP32()` timeout issue fixed.
* Timeouts handled more consistently.
* `queryWifi()`, `getNetworkStatus()`, and other command responses now use `response_code` enums where applicable.
* Added `CommandInterface.blink()` (for use with upcoming enDAQ firmware).
* Minor documentation improvements.