### PR TITLE
Feature/minor tweaks 2024 01 11

### DIFF
--- a/endaq/device/__init__.py
+++ b/endaq/device/__init__.py
@@ -87,9 +87,6 @@ def getRecorder(path: Filename,
     """
     global RECORDERS
 
-    if not isinstance(path, (str, Path, Drive)):
-        raise TypeError('Invalid type for path: {}'.format(type(path).__name__))
-
     dev = None
 
     for rtype in RECORDER_TYPES:

--- a/endaq/device/__init__.py
+++ b/endaq/device/__init__.py
@@ -87,6 +87,9 @@ def getRecorder(path: Filename,
     """
     global RECORDERS
 
+    if not isinstance(path, (str, Path, Drive)):
+        raise TypeError('Invalid type for path: {}'.format(type(path).__name__))
+
     dev = None
 
     for rtype in RECORDER_TYPES:

--- a/endaq/device/base.py
+++ b/endaq/device/base.py
@@ -871,7 +871,7 @@ class Recorder:
             pass
 
 
-    def _readUserpage(self) -> Union[dict, None]:
+    def _readUserpage(self) -> Union[Dict[str, Any], None]:
         """ Read the device's manifest data from the EFM32 'userpage'. The
             data is a superset of the information returned by `getInfo()`.
             Factory calibration and recorder properties are also read
@@ -920,7 +920,7 @@ class Recorder:
         return self._manifest
 
 
-    def _readManifest(self) -> Union[dict, None]:
+    def _readManifest(self) -> Union[Dict[str, Any], None]:
         """ Read the device's manifest data from the 'MANIFEST' file. The
             data is a superset of the information returned by `getInfo()`.
 
@@ -1244,7 +1244,7 @@ class Recorder:
 
     @classmethod
     def generateCalEbml(cls,
-                        transforms: dict,
+                        transforms: Union[List[Transform], Dict[int, Transform]],
                         date: Optional[int] = None,
                         expires: Optional[int] = None,
                         calSerial: int = 0) -> ebmlite.Document:
@@ -1279,7 +1279,7 @@ class Recorder:
 
 
     def writeUserCal(self,
-                     transforms: dict,
+                     transforms: Union[List[Transform], Dict[int, Transform]],
                      filename: Union[str, Path, None] = None):
         """ Write user calibration to the SSX.
 

--- a/endaq/device/base.py
+++ b/endaq/device/base.py
@@ -19,7 +19,7 @@ from time import struct_time
 from typing import Any, AnyStr, Callable, Dict, Optional, Tuple, Union
 import warnings
 
-from idelib.dataset import Dataset, Channel
+from idelib.dataset import Dataset, Channel, SubChannel, Sensor
 from idelib import importer
 from idelib.parsers import CalibrationListParser, RecordingPropertiesParser
 from idelib.transforms import Transform
@@ -265,6 +265,8 @@ class Recorder:
 
     @property
     def path(self) -> Union[str, None]:
+        """ The recorder's filesystem path (e.g., drive letter or mount point).
+        """
         with self._busy:
             return self._path
 
@@ -766,7 +768,7 @@ class Recorder:
         return self._channelRanges[key]
 
 
-    def getAccelAxisChannels(self) -> dict:
+    def getAccelAxisChannels(self) -> dict[int, list[SubChannel]]:
         """ Retrieve a list of all accelerometer axis subchannels, ordered
             alphabetically (X, Y, Z).
 
@@ -954,7 +956,7 @@ class Recorder:
         return self._manifest
 
 
-    def getManifest(self) -> Union[dict, None]:
+    def getManifest(self) -> Union[dict[str, Any], None]:
         """ Read the device's manifest data. The data is a superset of the
             information returned by `getInfo()`.
         """
@@ -971,7 +973,7 @@ class Recorder:
 
 
     def getUserCalibration(self,
-                           filename: Optional[Filename] = None) -> Union[dict, None]:
+                           filename: Optional[Filename] = None) -> Union[dict[str, Any], None]:
         """ Get the recorder's user-defined calibration data as a dictionary
             of parameters.
         """
@@ -992,7 +994,7 @@ class Recorder:
 
 
     def getUserCalPolynomials(self,
-                              filename: Optional[Filename] = None) -> Union[dict, None]:
+                              filename: Optional[Filename] = None) -> Union[dict[int, Transform], None]:
         """ Get the recorder's user-defined calibration data as a dictionary
             of `idelib.transforms.Transform` subclass instances, keyed by ID.
 
@@ -1012,7 +1014,7 @@ class Recorder:
         return self._userCalPolys
 
 
-    def getCalibration(self, user: bool = True) -> Union[dict, None]:
+    def getCalibration(self, user: bool = True) -> Union[dict[str, Any], None]:
         """ Get the recorder's current calibration information. User-supplied
             calibration, if present, takes priority (as it is what will be
             applied in recordings).
@@ -1029,7 +1031,7 @@ class Recorder:
         return self._calibration
 
 
-    def getCalPolynomials(self, user: bool = True) -> Union[dict, None]:
+    def getCalPolynomials(self, user: bool = True) -> Union[dict[int, Transform], None]:
         """ Get the constructed Polynomial objects created from the device's
             current calibration data, as a dictionary of
             `idelib.transform.Transform` subclass instances, keyed by ID.
@@ -1128,7 +1130,7 @@ class Recorder:
 
 
     @property
-    def transforms(self) -> Union[dict, None]:
+    def transforms(self) -> Union[dict[int, Transform], None]:
         """ The recorder's calibration polynomials, a dictionary of
             `idelib.transform.Transform` subclass instances keyed by ID. For
             compatibility with `idelib.dataset.Dataset`; results are the
@@ -1137,7 +1139,7 @@ class Recorder:
         return self.getCalPolynomials()
 
 
-    def getProperties(self) -> dict:
+    def getProperties(self) -> dict[str, Any]:
         """ Get the raw Recording Properties from the device.
         """
         if self.isVirtual or self._properties is not None:
@@ -1150,7 +1152,7 @@ class Recorder:
         return self._properties
 
 
-    def getSensors(self) -> dict:
+    def getSensors(self) -> dict[int, Sensor]:
         """ Get the recorder sensor description data.
         """
         self.getManifest()
@@ -1188,17 +1190,25 @@ class Recorder:
 
 
     @property
-    def sensors(self) -> dict:
+    def sensors(self) -> dict[int, Sensor]:
+        """ The device's sensors; a dictionary of `Sensor` objects keyed by
+            sensor ID. For compatibility with `idelib.dataset.Dataset`; results
+            are the same as `Recorder.getSensors()`.
+        """
         return self.getSensors()
 
 
     @property
-    def channels(self) -> dict:
+    def channels(self) -> dict[int, Channel]:
+        """ The devices recording channels; a dictionary of `Channel` objects
+            keyed by channel ID. For compatibility with `idelib.dataset.Dataset`;
+            results are the same as `Recorder.getChannels(mtype=None)`.
+        """
         self.getSensors()
         return self._channels.copy()
 
 
-    def getChannels(self, mtype: Union[MeasurementType, str, None] = None) -> dict:
+    def getChannels(self, mtype: Union[MeasurementType, str, None] = None) -> dict[int, Channel]:
         """ Get the recorder channel description data.
 
             :param mtype: An optional measurement type, to filter results.
@@ -1213,7 +1223,7 @@ class Recorder:
             return self._channels.copy()
 
 
-    def getSubchannels(self, mtype: Union[MeasurementType, str, None] = None) -> dict:
+    def getSubchannels(self, mtype: Union[MeasurementType, str, None] = None) -> list[SubChannel]:
         """ Get the recorder subchannel description data.
 
             :param mtype: An optional measurement type, to filter results. See

--- a/endaq/device/base.py
+++ b/endaq/device/base.py
@@ -16,7 +16,7 @@ import struct
 import sys
 from threading import RLock
 from time import struct_time
-from typing import Any, AnyStr, Callable, Dict, Optional, Tuple, Union
+from typing import Any, AnyStr, Callable, Dict, List, Optional, Tuple, Union
 import warnings
 
 from idelib.dataset import Dataset, Channel, SubChannel, Sensor
@@ -768,7 +768,7 @@ class Recorder:
         return self._channelRanges[key]
 
 
-    def getAccelAxisChannels(self) -> dict[int, list[SubChannel]]:
+    def getAccelAxisChannels(self) -> Dict[int, List[SubChannel]]:
         """ Retrieve a list of all accelerometer axis subchannels, ordered
             alphabetically (X, Y, Z).
 
@@ -956,7 +956,7 @@ class Recorder:
         return self._manifest
 
 
-    def getManifest(self) -> Union[dict[str, Any], None]:
+    def getManifest(self) -> Union[Dict[str, Any], None]:
         """ Read the device's manifest data. The data is a superset of the
             information returned by `getInfo()`.
         """
@@ -973,7 +973,7 @@ class Recorder:
 
 
     def getUserCalibration(self,
-                           filename: Optional[Filename] = None) -> Union[dict[str, Any], None]:
+                           filename: Optional[Filename] = None) -> Union[Dict[str, Any], None]:
         """ Get the recorder's user-defined calibration data as a dictionary
             of parameters.
         """
@@ -994,7 +994,7 @@ class Recorder:
 
 
     def getUserCalPolynomials(self,
-                              filename: Optional[Filename] = None) -> Union[dict[int, Transform], None]:
+                              filename: Optional[Filename] = None) -> Union[Dict[int, Transform], None]:
         """ Get the recorder's user-defined calibration data as a dictionary
             of `idelib.transforms.Transform` subclass instances, keyed by ID.
 
@@ -1014,7 +1014,7 @@ class Recorder:
         return self._userCalPolys
 
 
-    def getCalibration(self, user: bool = True) -> Union[dict[str, Any], None]:
+    def getCalibration(self, user: bool = True) -> Union[Dict[str, Any], None]:
         """ Get the recorder's current calibration information. User-supplied
             calibration, if present, takes priority (as it is what will be
             applied in recordings).
@@ -1031,7 +1031,7 @@ class Recorder:
         return self._calibration
 
 
-    def getCalPolynomials(self, user: bool = True) -> Union[dict[int, Transform], None]:
+    def getCalPolynomials(self, user: bool = True) -> Union[Dict[int, Transform], None]:
         """ Get the constructed Polynomial objects created from the device's
             current calibration data, as a dictionary of
             `idelib.transform.Transform` subclass instances, keyed by ID.
@@ -1130,7 +1130,7 @@ class Recorder:
 
 
     @property
-    def transforms(self) -> Union[dict[int, Transform], None]:
+    def transforms(self) -> Union[Dict[int, Transform], None]:
         """ The recorder's calibration polynomials, a dictionary of
             `idelib.transform.Transform` subclass instances keyed by ID. For
             compatibility with `idelib.dataset.Dataset`; results are the
@@ -1139,7 +1139,7 @@ class Recorder:
         return self.getCalPolynomials()
 
 
-    def getProperties(self) -> dict[str, Any]:
+    def getProperties(self) -> Dict[str, Any]:
         """ Get the raw Recording Properties from the device.
         """
         if self.isVirtual or self._properties is not None:
@@ -1152,7 +1152,7 @@ class Recorder:
         return self._properties
 
 
-    def getSensors(self) -> dict[int, Sensor]:
+    def getSensors(self) -> Dict[int, Sensor]:
         """ Get the recorder sensor description data.
         """
         self.getManifest()
@@ -1190,7 +1190,7 @@ class Recorder:
 
 
     @property
-    def sensors(self) -> dict[int, Sensor]:
+    def sensors(self) -> Dict[int, Sensor]:
         """ The device's sensors; a dictionary of `Sensor` objects keyed by
             sensor ID. For compatibility with `idelib.dataset.Dataset`; results
             are the same as `Recorder.getSensors()`.
@@ -1199,7 +1199,7 @@ class Recorder:
 
 
     @property
-    def channels(self) -> dict[int, Channel]:
+    def channels(self) -> Dict[int, Channel]:
         """ The devices recording channels; a dictionary of `Channel` objects
             keyed by channel ID. For compatibility with `idelib.dataset.Dataset`;
             results are the same as `Recorder.getChannels(mtype=None)`.
@@ -1208,7 +1208,7 @@ class Recorder:
         return self._channels.copy()
 
 
-    def getChannels(self, mtype: Union[MeasurementType, str, None] = None) -> dict[int, Channel]:
+    def getChannels(self, mtype: Union[MeasurementType, str, None] = None) -> Dict[int, Channel]:
         """ Get the recorder channel description data.
 
             :param mtype: An optional measurement type, to filter results.
@@ -1223,7 +1223,7 @@ class Recorder:
             return self._channels.copy()
 
 
-    def getSubchannels(self, mtype: Union[MeasurementType, str, None] = None) -> list[SubChannel]:
+    def getSubchannels(self, mtype: Union[MeasurementType, str, None] = None) -> List[SubChannel]:
         """ Get the recorder subchannel description data.
 
             :param mtype: An optional measurement type, to filter results. See

--- a/endaq/device/command_interfaces.py
+++ b/endaq/device/command_interfaces.py
@@ -1449,7 +1449,7 @@ class SerialCommandInterface(CommandInterface):
 
         if port.in_waiting:
             logger.debug('Flushing {} bytes from serial input'.format(port.in_waiting))
-            port.flushInput()
+            port.reset_input_buffer()
 
         return port.write(packet)
 
@@ -1740,8 +1740,8 @@ class SerialCommandInterface(CommandInterface):
             seconds, continuing for the specified duration. `a` and `b`
             are unsigned 8 bit integers, in which each bit represents one
             of the recorder's LEDs:
-                * Bit 0 (LSB): Red
-                * Bit 1: Green
+                * Bit 0 (LSB): Green
+                * Bit 1: Red
                 * Bit 2: Blue
                 * Bits 3-7: Reserved for future use.
 

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,6 @@ setuptools.setup(
         classifiers=['Development Status :: 5 - Production/Stable',
                      'License :: OSI Approved :: MIT License',
                      'Natural Language :: English',
-                     'Programming Language :: Python :: 3.7',
                      'Programming Language :: Python :: 3.8',
                      'Programming Language :: Python :: 3.9',
                      'Programming Language :: Python :: 3.10',

--- a/tests/mock_hardware.py
+++ b/tests/mock_hardware.py
@@ -57,7 +57,13 @@ class MockPort:
     def flushInput(self):
         pass
 
+    def reset_input_buffer(self):
+        pass
+
     def flushOutput(self):
+        pass
+
+    def reset_output_buffer(self):
         pass
 
     def flush(self):


### PR DESCRIPTION
* Corrected mapping of bits to LEDs in `CommandInterface.blink()`
* Updated call to `Serial.flushInput()` (deprecated name) to `Serial.reset_input_buffer()` (new name)
* Updated `MockPort` text fixture to include use new `Serial` method names.
* Expanded type annotation in `Recorder`
* Added some missing property docstrings
* Removed Python 3.7 from `setup.py`
