### PR TITLE
added ncp element to schema revision

### DIFF
--- a/endaq/device/schemata/flash_package.xml
+++ b/endaq/device/schemata/flash_package.xml
@@ -46,10 +46,10 @@
     <MasterElement name="NcpUpdate" id="0x80" mandatory="0" multiple="0">
         <StringElement name="NcpType" id="0x81" multiple="0" mandatory="1"> NCP chip type the update is meant for</StringElement>
         <StringElement name="Ncp" id="0x82" multiple="0" mandatory="1"> NCP update file</StringElement>
-        <UIntegerElement name="NcpFwRev" multiple="0" mandatory="1"> NCP firmware vers. single digit format</UIntegerElement>
-        <StringElement name="NcpFwRevString" multiple="0" mandatory="0"> NCP firmware vers. triple digit format</StringElement>
-        <IntegerElement name="NcpKeySlot" multiple="0" mandatory="1"> Encryption key used to decrypt NCP file</IntegerElement>
-        <BinaryElement name="NcpUpdateData" multiple="0" mandatory="0"> The body of the ncp update (encrypted in public use)</BinaryElement>
+        <UIntegerElement name="NcpFwRev" id="0x83"   multiple="0" mandatory="1"> NCP firmware vers. single digit format</UIntegerElement>
+        <StringElement name="NcpFwRevString" id="0x84" multiple="0" mandatory="0"> NCP firmware vers. triple digit format</StringElement>
+        <IntegerElement name="NcpKeySlot"  id="0x85" multiple="0" mandatory="1"> Encryption key used to decrypt NCP file</IntegerElement>
+        <BinaryElement name="NcpUpdateData" id="0x86" multiple="0" mandatory="0"> The body of the ncp update (encrypted in public use)</BinaryElement>
 
     </MasterElement>
     </MasterElement> <!-- UpdatePkg -->

--- a/endaq/device/schemata/flash_package.xml
+++ b/endaq/device/schemata/flash_package.xml
@@ -39,7 +39,7 @@
     <StringElement name="McuType" id="0xF6" multiple="0" mandatory="1"> Processor the attached update is intended for. Values include "EFM32GG11B820F2048GL120", "STM32U585AII6", or "ANY" for non-firmware updates</StringElement>
     <StringElement name="FWRevString" id="0xF7" multiple="0" mandatory="0"> Human readable firmware revision</StringElement>
     <StringElement name="UpdateNotes" id="0xF8" multiple="0" mandatory="0"> Human readable notes regarding the update</StringElement>
-    <MasterElement name="NonCriticalElements" global="1" id="0xE0" multiple="0" mandatory="0"></MasterElement>
+    <MasterElement name="NonCriticalElements" global="1" id="0xE0" multiple="0" mandatory="0">The device may skip elements inside NonCriticalElements without stopping the update. Any other unrecognized elements will kill the firmware update.</MasterElement>
     <!-- Additional element for NCP (EFM currently) information. Not strictly necessary but for newer models allows simultaneous updating of the NCP -->
     <MasterElement name="NcpUpdate" id="0x80" mandatory="0" multiple="0">
         <StringElement name="NcpType" id="0x86" multiple="0" mandatory="1"> NCP chip type the update is meant for</StringElement>

--- a/endaq/device/schemata/flash_package.xml
+++ b/endaq/device/schemata/flash_package.xml
@@ -48,6 +48,7 @@
         <StringElement name="NcpFwRevString" id="0x87" multiple="0" mandatory="0"> NCP firmware vers. triple digit format</StringElement>
         <IntegerElement name="NcpKeySlot"  id="0x84" multiple="0" mandatory="1"> Encryption key used to decrypt NCP file</IntegerElement>
         <IntegerElement name="NcpPayloadLen" id="0x85" multiple="0" mandatory="1"> Length of NCP encrypted payload of the following format: 1 or more of (uint16 byte offset || uint16 length || [length] bytes of binary data to flash)</IntegerElement>
+        <BinaryElement name="NcpUpdateData" id="0x810" multiple="0" mandatory="1"> The binary contents of the NCP update</BinaryElement>
     </MasterElement> <!-- UpdatePkg -->
 
 </MasterElement> <!-- UpdatePkg -->

--- a/endaq/device/schemata/flash_package.xml
+++ b/endaq/device/schemata/flash_package.xml
@@ -36,19 +36,18 @@
     <UIntegerElement name="MinFWRev" id="0xF3" multiple="0" mandatory="0"> Minimum firmware version that can receive this update (in case of interface changes)</UIntegerElement>
 	<IntegerElement name="KeySlot" id="0xF4" multiple="0" mandatory="1"> AES Key slot used to encrypt payload (-1 for unencrypted payload)</IntegerElement>
 	<IntegerElement name="PayloadLen" id="0xF5" multiple="0" mandatory="1"> Length of following encrypted payload  of the following format: 1 or more of (uint16 byte offset || uint16 length || [length] bytes of binary data to flash)</IntegerElement>
-    <StringElement name="McuType" id="0xF6" multiple="0" mandatory="1"> Processor the attached update is intended for. Values include "EFM32GG11B820F2048GL120", "STM32U585AII6", or "ANY" for non-firmware updates</StringElement>
+    <StringElement name="TargetProcessor" id="0xF6" multiple="0" mandatory="1"> Processor the attached update is intended for. Values include "EFM32GG11B820F2048GL120", "STM32U585AII6", or "ANY" for non-firmware updates</StringElement>
     <StringElement name="FWRevString" id="0xF7" multiple="0" mandatory="0"> Human readable firmware revision</StringElement>
     <StringElement name="UpdateNotes" id="0xF8" multiple="0" mandatory="0"> Human readable notes regarding the update</StringElement>
     <MasterElement name="NonCriticalElements" global="1" id="0xE0" multiple="0" mandatory="0">The device may skip elements inside NonCriticalElements without stopping the update. Any other unrecognized elements will kill the firmware update.</MasterElement>
     <!-- Additional element for NCP (EFM currently) information. Not strictly necessary but for newer models allows simultaneous updating of the NCP -->
     <MasterElement name="NcpUpdate" id="0x80" mandatory="0" multiple="0">
         <StringElement name="NcpType" id="0x86" multiple="0" mandatory="1"> NCP chip type the update is meant for</StringElement>
-        <StringElement name="Ncp" id="0x89" multiple="0" mandatory="1"> NCP update file</StringElement>
         <UIntegerElement name="NcpFwRev" id="0x82"   multiple="0" mandatory="1"> NCP firmware vers. single digit format</UIntegerElement>
         <StringElement name="NcpFwRevString" id="0x87" multiple="0" mandatory="0"> NCP firmware vers. triple digit format</StringElement>
         <IntegerElement name="NcpKeySlot"  id="0x84" multiple="0" mandatory="1"> Encryption key used to decrypt NCP file</IntegerElement>
         <IntegerElement name="NcpPayloadLen" id="0x85" multiple="0" mandatory="1"> Length of NCP encrypted payload of the following format: 1 or more of (uint16 byte offset || uint16 length || [length] bytes of binary data to flash)</IntegerElement>
-        <BinaryElement name="NcpUpdateData" id="0x810" multiple="0" mandatory="1"> The binary contents of the NCP update</BinaryElement>
+        <BinaryElement name="NcpUpdateData" id="0x81" multiple="0" mandatory="1"> The binary contents of the NCP update</BinaryElement>
     </MasterElement> <!-- UpdatePkg -->
 
 </MasterElement> <!-- UpdatePkg -->

--- a/endaq/device/schemata/flash_package.xml
+++ b/endaq/device/schemata/flash_package.xml
@@ -29,7 +29,7 @@
         </MasterElement>
 </MasterElement>
 
-	<!-- Only the following elements must exist in the update package -->
+		<!-- Only the following elements must exist in the update package -->
 <MasterElement name="UpdatePkg" id="0xF0" mandatory="1" multiple="0">
     <UIntegerElement name="MinHWRev" id="0xF1" multiple="0" mandatory="1"> Minimum Hardware Rev this update can be applied to</UIntegerElement>
     <UIntegerElement name="FWRev" id="0xF2" multiple="0" mandatory="1"> FW Revision contained in this package (may be 0 for non firmware updates)</UIntegerElement>
@@ -42,12 +42,12 @@
     <MasterElement name="NonCriticalElements" global="1" id="0xE0" multiple="0" mandatory="0"></MasterElement>
     <!-- Additional element for NCP (EFM currently) information. Not strictly necessary but for newer models allows simultaneous updating of the NCP -->
     <MasterElement name="NcpUpdate" id="0x80" mandatory="0" multiple="0">
-        <StringElement name="NcpType" id="0x81" multiple="0" mandatory="1"> NCP chip type the update is meant for</StringElement>
-        <StringElement name="Ncp" id="0x82" multiple="0" mandatory="1"> NCP update file</StringElement>
-        <UIntegerElement name="NcpFwRev" id="0x83"   multiple="0" mandatory="1"> NCP firmware vers. single digit format</UIntegerElement>
-        <StringElement name="NcpFwRevString" id="0x84" multiple="0" mandatory="0"> NCP firmware vers. triple digit format</StringElement>
-        <IntegerElement name="NcpKeySlot"  id="0x85" multiple="0" mandatory="1"> Encryption key used to decrypt NCP file</IntegerElement>
-        <BinaryElement name="NcpUpdateData" id="0x86" multiple="0" mandatory="0"> The body of the ncp update (encrypted in public use)</BinaryElement>
+        <StringElement name="NcpType" id="0x86" multiple="0" mandatory="1"> NCP chip type the update is meant for</StringElement>
+        <StringElement name="Ncp" id="0x89" multiple="0" mandatory="1"> NCP update file</StringElement>
+        <UIntegerElement name="NcpFwRev" id="0x82"   multiple="0" mandatory="1"> NCP firmware vers. single digit format</UIntegerElement>
+        <StringElement name="NcpFwRevString" id="0x87" multiple="0" mandatory="0"> NCP firmware vers. triple digit format</StringElement>
+        <IntegerElement name="NcpKeySlot"  id="0x84" multiple="0" mandatory="1"> Encryption key used to decrypt NCP file</IntegerElement>
+        <IntegerElement name="NcpPayloadLen" id="0x85" multiple="0" mandatory="1"> Length of NCP encrypted payload of the following format: 1 or more of (uint16 byte offset || uint16 length || [length] bytes of binary data to flash)</IntegerElement>
     </MasterElement> <!-- UpdatePkg -->
 
 </MasterElement> <!-- UpdatePkg -->

--- a/endaq/device/schemata/flash_package.xml
+++ b/endaq/device/schemata/flash_package.xml
@@ -40,6 +40,18 @@
     <StringElement name="FWRevString" id="0xF7" multiple="0" mandatory="0"> Human readable firmware revision</StringElement>
     <StringElement name="UpdateNotes" id="0xF8" multiple="0" mandatory="0"> Human readable notes regarding the update</StringElement>
     <MasterElement name="NonCriticalElements" global="1" id="0xE0" multiple="0" mandatory="0">The device may skip elements inside NonCriticalElements without stopping the update. Any other unrecognized elements will kill the firmware update.
+
+
+        <!-- Additional element for NCP (EFM currently) information. Not strictly necessary but for newer models allows simultaneous updating of the NCP -->
+    <MasterElement name="NcpUpdate" id="0x80" mandatory="0" multiple="0">
+        <StringElement name="NcpType" id="0x81" multiple="0" mandatory="1"> NCP chip type the update is meant for</StringElement>
+        <StringElement name="Ncp" id="0x82" multiple="0" mandatory="1"> NCP update file</StringElement>
+        <UIntegerElement name="NcpFwRev" multiple="0" mandatory="1"> NCP firmware vers. single digit format</UIntegerElement>
+        <StringElement name="NcpFwRevString" multiple="0" mandatory="0"> NCP firmware vers. triple digit format</StringElement>
+        <IntegerElement name="NcpKeySlot" multiple="0" mandatory="1"> Encryption key used to decrypt NCP file</IntegerElement>
+        <BinaryElement name="NcpUpdateData" multiple="0" mandatory="0"> The body of the ncp update (encrypted in public use)</BinaryElement>
+
+    </MasterElement>
     </MasterElement> <!-- UpdatePkg -->
 
 </MasterElement> <!-- UpdatePkg -->

--- a/endaq/device/schemata/flash_package.xml
+++ b/endaq/device/schemata/flash_package.xml
@@ -4,7 +4,7 @@
         <Author>Derek Witt</Author>
         <Description>Metadata and packing format for encrypted update packages</Description>
     </SchemaInfo>
-	
+
 	    <!-- Base EBML elements. Required. (but not included in produced update package)-->
     <MasterElement name="EBML" id="0x1A45DFA3" mandatory="1" multiple="0" minver="1">Set the EBML characteristics of the data to follow. Each EBML document has to start with this.
         <UIntegerElement name="EBMLVersion" id="0x4286" multiple="0" mandatory="1" default="1" minver="1">The version of EBML parser used to create the file.</UIntegerElement>
@@ -28,7 +28,7 @@
             </MasterElement>
         </MasterElement>
 </MasterElement>
-	
+
 	<!-- Only the following elements must exist in the update package -->
 <MasterElement name="UpdatePkg" id="0xF0" mandatory="1" multiple="0">
     <UIntegerElement name="MinHWRev" id="0xF1" multiple="0" mandatory="1"> Minimum Hardware Rev this update can be applied to</UIntegerElement>
@@ -36,13 +36,11 @@
     <UIntegerElement name="MinFWRev" id="0xF3" multiple="0" mandatory="0"> Minimum firmware version that can receive this update (in case of interface changes)</UIntegerElement>
 	<IntegerElement name="KeySlot" id="0xF4" multiple="0" mandatory="1"> AES Key slot used to encrypt payload (-1 for unencrypted payload)</IntegerElement>
 	<IntegerElement name="PayloadLen" id="0xF5" multiple="0" mandatory="1"> Length of following encrypted payload  of the following format: 1 or more of (uint16 byte offset || uint16 length || [length] bytes of binary data to flash)</IntegerElement>
-    <StringElement name="TargetProcessor" id="0xF6" multiple="0" mandatory="1"> Processor the attached update is intended for. Values include "EFM32GG11B820F2048GL120", "STM32U585AII6", or "ANY" for non-firmware updates</StringElement>
+    <StringElement name="McuType" id="0xF6" multiple="0" mandatory="1"> Processor the attached update is intended for. Values include "EFM32GG11B820F2048GL120", "STM32U585AII6", or "ANY" for non-firmware updates</StringElement>
     <StringElement name="FWRevString" id="0xF7" multiple="0" mandatory="0"> Human readable firmware revision</StringElement>
     <StringElement name="UpdateNotes" id="0xF8" multiple="0" mandatory="0"> Human readable notes regarding the update</StringElement>
-    <MasterElement name="NonCriticalElements" global="1" id="0xE0" multiple="0" mandatory="0">The device may skip elements inside NonCriticalElements without stopping the update. Any other unrecognized elements will kill the firmware update.
-
-
-        <!-- Additional element for NCP (EFM currently) information. Not strictly necessary but for newer models allows simultaneous updating of the NCP -->
+    <MasterElement name="NonCriticalElements" global="1" id="0xE0" multiple="0" mandatory="0"></MasterElement>
+    <!-- Additional element for NCP (EFM currently) information. Not strictly necessary but for newer models allows simultaneous updating of the NCP -->
     <MasterElement name="NcpUpdate" id="0x80" mandatory="0" multiple="0">
         <StringElement name="NcpType" id="0x81" multiple="0" mandatory="1"> NCP chip type the update is meant for</StringElement>
         <StringElement name="Ncp" id="0x82" multiple="0" mandatory="1"> NCP update file</StringElement>
@@ -50,8 +48,6 @@
         <StringElement name="NcpFwRevString" id="0x84" multiple="0" mandatory="0"> NCP firmware vers. triple digit format</StringElement>
         <IntegerElement name="NcpKeySlot"  id="0x85" multiple="0" mandatory="1"> Encryption key used to decrypt NCP file</IntegerElement>
         <BinaryElement name="NcpUpdateData" id="0x86" multiple="0" mandatory="0"> The body of the ncp update (encrypted in public use)</BinaryElement>
-
-    </MasterElement>
     </MasterElement> <!-- UpdatePkg -->
 
 </MasterElement> <!-- UpdatePkg -->


### PR DESCRIPTION
This branch contains the NcpUpdate element that contains relevant information about the NCP (ESP chip) so that it can be updated in the same package as the STM/EFM using this schema. REVISED to fix missing IDs