### PR TITLE
Feature/es 600 improved `recorder.available`

### DIFF
--- a/endaq/device/base.py
+++ b/endaq/device/base.py
@@ -238,7 +238,7 @@ class Recorder:
                 RECORDERS[hash(dev)] = self
                 RECORDERS.pop(hash(self), None)
                 self._virtual = False
-                if dev.path:
+                if dev.path != self.path:
                     self.path = dev.path
                 self.refresh(force=True)
                 return True


### PR DESCRIPTION
### Rewrote `Recorder.available`
Previously, `Recorder.available` only checked whether the path exists. This caused problems in cases in which one recorder was attached and another removed, and the new one was assigned the old one's path/drive letter. Now, it checks for the path and compares `DEVINFO` hashes.

### Added `Recorder.update()`
This method finds the hardware corresponding to the `Recorder`, updates the path (if necessary), and reloads the device information. Primarily for use after applying a FW or userpage update. `update()` can also be used to try to turn a 'virtual' device (instantiated from a recording) into a 'real' device by linking it to the corresponding hardware (if present).

### Added `update` parameter to `CommandInterface.awaitRemount()`
`awaitRemount()` can now (optionally) attempt to update `Recorder` information, useful if a FW/userpage update was applied.

### Other
* Added lock to recorder-finding functions.
* Separated the notion of 'virtual' and 'unmounted' devices (baby steps toward remote access/control)
* Docstring addition/improvement
* Little fixes