### PR TITLE
Added `stopRecording()` command

### DIFF
--- a/endaq/device/command_interfaces.py
+++ b/endaq/device/command_interfaces.py
@@ -456,7 +456,6 @@ class CommandInterface:
                        timeout: Union[int, float] = 5,
                        callback: Optional[Callable] = None) -> bool:
         """ Start the device recording, if supported.
-            Must be implemented in every subclass.
 
             :param timeout: Time (in seconds) to wait for a response before
                 raising a `DeviceTimeout` exception. `None` or -1 will wait
@@ -467,7 +466,23 @@ class CommandInterface:
                 require no arguments.
             :returns: `True` if the command was successful.
         """
-        raise NotImplementedError
+        raise UnsupportedFeature(self, self.startRecording)
+
+
+    def stopRecording(self,
+                      timeout: Union[int, float] = 5,
+                      callback: Optional[Callable] = None):
+        """ Stop a device that is recording, if supported.
+
+            :param timeout: Time (in seconds) to wait for the recorder to
+                respond. 0 will return immediately.
+            :param callback: A function to call each response-checking
+                cycle. If the callback returns `True`, the wait for a response
+                will be cancelled. The callback function should require no
+                arguments.
+            :returns: `True` if the command was successful.
+        """
+        raise UnsupportedFeature(self, self.stopRecording)
 
 
     def reset(self,

--- a/endaq/device/command_interfaces.py
+++ b/endaq/device/command_interfaces.py
@@ -1848,7 +1848,7 @@ class SerialCommandInterface(CommandInterface):
             :returns: `True` if the command was successful.
         """
         self._sendCommand({'EBMLCommand': {'RecStop': {}}},
-                          response=False,
+                          response=True,
                           timeout=timeout,
                           callback=callback)
 

--- a/endaq/device/command_interfaces.py
+++ b/endaq/device/command_interfaces.py
@@ -1834,6 +1834,25 @@ class SerialCommandInterface(CommandInterface):
                                       callback=callback)
 
 
+    def stopRecording(self,
+                      timeout: Union[int, float] = 5,
+                      callback: Optional[Callable] = None):
+        """ Stop a device that is recording.
+
+            :param timeout: Time (in seconds) to wait for the recorder to
+                respond. 0 will return immediately.
+            :param callback: A function to call each response-checking
+                cycle. If the callback returns `True`, the wait for a response
+                will be cancelled. The callback function should require no
+                arguments.
+            :returns: `True` if the command was successful.
+        """
+        self._sendCommand({'EBMLCommand': {'RecStop': {}}},
+                          response=False,
+                          timeout=timeout,
+                          callback=callback)
+
+
     def reset(self,
               wait: bool = True,
               timeout: Union[int, float] = 5,

--- a/endaq/device/command_interfaces.py
+++ b/endaq/device/command_interfaces.py
@@ -1365,7 +1365,7 @@ class SerialCommandInterface(CommandInterface):
 
         deadline = time() + timeout
 
-        while timeout > 0 and time() < deadline:
+        while timeout < 0 or time() < deadline:
             try:
                 portname = self.findSerialPort(self.device)
 
@@ -1478,7 +1478,7 @@ class SerialCommandInterface(CommandInterface):
         timeout = -1 if timeout is None else timeout
         deadline = time() + timeout
 
-        while timeout > 0 and time() < deadline:
+        while timeout < 0 or time() < deadline:
             try:
                 port = self.getSerialPort()
 


### PR DESCRIPTION
This adds the simple `stopRecording()` command. 

Note: This is being created as a draft PR until it can be confirmed the serial port timeout changes do not have adverse side effects (e.g., make standard operations slower).