### PR TITLE
Feature/es 633 CommandInterface._getInfo()

### DIFF
--- a/endaq/device/command_interfaces.py
+++ b/endaq/device/command_interfaces.py
@@ -1764,7 +1764,7 @@ class SerialCommandInterface(CommandInterface):
                 dt = response['ClockTime']
                 devTime = self.device._TIME_PARSER.unpack_from(dt)[0]
             except KeyError:
-                raise CommandError("GetClock response did not contain ClockTime")
+                raise DeviceError("GetClock response did not contain ClockTime")
 
         return sysTime, devTime
 
@@ -1835,7 +1835,7 @@ class SerialCommandInterface(CommandInterface):
                                      callback=callback)
 
         if 'PingReply' not in response:
-            raise CommandError('Ping response did not contain a PingReply')
+            raise DeviceError('Ping response did not contain a PingReply')
 
         return response['PingReply']
 
@@ -2106,14 +2106,13 @@ class SerialCommandInterface(CommandInterface):
                                      timeout=timeout,
                                      callback=callback)
 
-        # XXX: update GetInfoResp if/when element name changes to GetInfoResponse
         try:
-            return response['GetInfoResp']['InfoPayload']
+            return response['GetInfoResponse']['InfoPayload']
         except KeyError:
-            if 'GetInfoResp' in response:
-                raise CommandError('Response did not contain expected GetInfoResponse element')
+            if 'GetInfoResponse' in response:
+                raise DeviceError('Response did not contain expected GetInfoResponse element')
             else:
-                raise CommandError('Response did not contain a payload of information')
+                raise DeviceError('Response did not contain a payload of information')
 
 
     def _setInfo(self,

--- a/endaq/device/command_interfaces.py
+++ b/endaq/device/command_interfaces.py
@@ -1211,6 +1211,55 @@ class CommandInterface:
         return mac, ip
 
 
+    # =======================================================================
+    # General device info getting/setting
+    # =======================================================================
+
+    def _getInfo(self,
+                index: int,
+                timeout: Union[int, float] = 10,
+                interval: float = .25,
+                callback: Optional[Callable] = None) -> ByteString:
+        """ Retrieve device system information. For 'local' devices, this
+            is retrieved via the filesystem. This method is called indirectly
+            by methods in `Recorder`.
+
+            :param index: The index of the information to retrieve.
+            :param timeout: Time (in seconds) to wait for a response before
+                raising a :class:`~.endaq.device.DeviceTimeout` exception.
+                `None` or -1 will wait indefinitely.
+            :param interval: Time (in seconds) between checks for a response.
+            :param callback: A function to call each response-checking cycle.
+                If the callback returns `True`, the wait for a response will
+                be cancelled. The callback function should require no arguments.
+            :return: The raw info, as unparsed EBML binary data. It is up to
+                the caller to know how to process the results (e.g., choose
+                the correct schema, etc.).
+        """
+        raise UnsupportedFeature(self, self._getInfo)
+
+
+    def _setInfo(self,
+                 index: int,
+                 payload: ByteString,
+                 timeout: Union[int, float] = 10,
+                 interval: float = .25,
+                 callback: Optional[Callable] = None):
+        """ Write device system information. This method is called indirectly
+            by methods in `Recorder`.
+
+            :param index: The index of the information to write.
+            :param timeout: Time (in seconds) to wait for a response before
+                raising a :class:`~.endaq.device.DeviceTimeout` exception.
+                `None` or -1 will wait indefinitely.
+            :param interval: Time (in seconds) between checks for a response.
+            :param callback: A function to call each response-checking cycle.
+                If the callback returns `True`, the wait for a response will
+                be cancelled. The callback function should require no arguments.
+        """
+        raise UnsupportedFeature(self, self._setInfo)
+
+
 # ===========================================================================
 #
 # ===========================================================================
@@ -2024,6 +2073,69 @@ class SerialCommandInterface(CommandInterface):
                               'FileCommandInterface')
 
         return self._fileinterface.scanWifi(timeout, interval, callback)
+
+
+    # =======================================================================
+    # General device info getting/setting
+    # =======================================================================
+
+    def _getInfo(self,
+                index: int,
+                timeout: Union[int, float] = 10,
+                interval: float = .25,
+                callback: Optional[Callable] = None) -> ByteString:
+        """ Retrieve device system information. For 'local' devices, this
+            is retrieved via the filesystem. This method is called indirectly
+            by methods in `Recorder`.
+
+            :param index: The index of the information to retrieve.
+            :param timeout: Time (in seconds) to wait for a response before
+                raising a :class:`~.endaq.device.DeviceTimeout` exception.
+                `None` or -1 will wait indefinitely.
+            :param interval: Time (in seconds) between checks for a response.
+            :param callback: A function to call each response-checking cycle.
+                If the callback returns `True`, the wait for a response will
+                be cancelled. The callback function should require no arguments.
+            :return: The raw info, as unparsed EBML binary data. It is up to
+                the caller to know how to process the results (e.g., choose
+                the correct schema, etc.).
+        """
+        cmd = {'EBMLCommand': {'GetInfo': index}}
+        response = self._sendCommand(cmd,
+                                     response=True,
+                                     timeout=timeout,
+                                     callback=callback)
+
+        # XXX: update GetInfoResp if/when element name changes to GetInfoResponse
+        try:
+            return response['GetInfoResp']['InfoPayload']
+        except KeyError:
+            if 'GetInfoResp' in response:
+                raise CommandError('Response did not contain expected GetInfoResponse element')
+            else:
+                raise CommandError('Response did not contain a payload of information')
+
+
+    def _setInfo(self,
+                 index: int,
+                 payload: ByteString,
+                 timeout: Union[int, float] = 10,
+                 interval: float = .25,
+                 callback: Optional[Callable] = None):
+        """ Write device system information. This method is called indirectly
+            by methods in `Recorder`.
+
+            :param index: The index of the information to write.
+            :param timeout: Time (in seconds) to wait for a response before
+                raising a :class:`~.endaq.device.DeviceTimeout` exception.
+                `None` or -1 will wait indefinitely.
+            :param interval: Time (in seconds) between checks for a response.
+            :param callback: A function to call each response-checking cycle.
+                If the callback returns `True`, the wait for a response will
+                be cancelled. The callback function should require no arguments.
+        """
+        # TODO: Implement `SerialCommandInterface._setInfo()`!
+        raise NotImplementedError
 
 
 # ===========================================================================

--- a/endaq/device/response_codes.py
+++ b/endaq/device/response_codes.py
@@ -18,11 +18,13 @@ class DeviceStatusCode(IntEnum):
     """ The device status, returned in the response to a command. Negative
         values denote errors.
     """
-    IDLE = 0  #: Device idle, message successful.
+    IDLE = 0  #: Device idle, message successful. It is implied the device is mounted as a drive.
+    IDLE_UNMOUNTED = 1  #: Device idle, not mounted as a drive. *For future use.*
     RECORDING = 10  #: Device is currently recording.
     RESET_PENDING = 20  #: Reset pending: the device will reset soon after this response is received.
     START_PENDING = 30  #: Recording start pending: the device will start recording soon after this response is received.
     TRIGGERING = 40 #: Device is currently triggering.
+    SLEEPING = 100  #: Device is currently in sleep mode, or will enter sleep mode soon after this response is received. *For future use.*
 
     ERR_BUSY = -10  #: Communication channel is busy
     ERR_INVALID_COMMAND = -20  #: Badly formed command
@@ -31,7 +33,7 @@ class DeviceStatusCode(IntEnum):
     ERR_UNKNOWN_COMMAND = -30  #: Command not recognized
     ERR_BAD_PAYLOAD = -40  #: Command payload is bad
     ERR_BAD_EBML = -50  #: Command EBML is malformed
-    ERR_RESPONSE_TOO_LARGE = -51 #: internal device error, EBML command response too large
+    ERR_RESPONSE_TOO_LARGE = -51  #: Internal device error, EBML command response too large
     ERR_BAD_CHECKSUM = -60  #: Command checksum failed (error transmitting packet)
     ERR_BAD_PACKET = -70  #: Content of command packet bad/damaged
 


### PR DESCRIPTION
Implements basic `CommandInterface._getInfo()` command, intended for internal use in upcoming PRs. Also adds a couple of response codes, which aren't directly related to this PR, but I wanted them in sooner rather than later.