### PR TITLE
Command decoding/response encoding

### DIFF
--- a/endaq/device/command_interfaces.py
+++ b/endaq/device/command_interfaces.py
@@ -1593,6 +1593,10 @@ class SerialCommandInterface(CommandInterface):
         medium. Only used in some special cases; not generally used in
         ordinary "Recorder" communication.
 
+        Note that the encoded results may not exactly match those generated
+        by a device, as the enDAQ firmware uses fixed lengths for element
+        size indicators some cases.
+
         :param packet: The unencoded command `dict`.
         :return: The encoded command data, with any class-specific
             wrapping or other preparations.

--- a/endaq/device/endaq.py
+++ b/endaq/device/endaq.py
@@ -184,7 +184,6 @@ class EndaqW(EndaqS):
 
     def updateESP32(self,
                     firmware: str,
-                    destination: Optional[str] = None,
                     timeout: float = 10,
                     callback: Optional[Callable] = None):
         """ Update the ESP32 firmware.
@@ -193,9 +192,6 @@ class EndaqW(EndaqS):
             instead.
 
             :param firmware: The name of the ESP32 firmware package (.bin).
-            :param destination: The name of the firmware package after being
-                copied to the device, an alternative to the default.
-                Optional; primarily for testing purposes.
             :param timeout: Time (in seconds) to wait for the recorder to
                 respond. 0 will return immediately.
             :param callback: A function to call each response-checking
@@ -209,6 +205,5 @@ class EndaqW(EndaqS):
                       "recorder.command.updateESP32()", DeprecationWarning)
 
         return self.command.updateESP32(firmware=firmware,
-                                        destination=destination,
                                         timeout=timeout,
                                         callback=callback)

--- a/endaq/device/exceptions.py
+++ b/endaq/device/exceptions.py
@@ -2,8 +2,9 @@
 Exceptions raised when interacting with a recording device.
 """
 
-__all__ = ('CommandError', 'ConfigError', 'ConfigVersionError',
-           'DeviceError', 'DeviceTimeout', 'UnsupportedFeature')
+__all__ = ('CommandError', 'CommunicationError', 'ConfigError',
+           'ConfigVersionError', 'DeviceError', 'DeviceTimeout',
+           'UnsupportedFeature')
 
 
 class DeviceError(Exception):
@@ -16,6 +17,10 @@ class DeviceError(Exception):
 
 
 class CommandError(RuntimeError, DeviceError):
+    """ Exception raised by a failure to process a command. """
+
+
+class CommunicationError(RuntimeError, DeviceError):
     """ Exception raised by a failure to communicate. """
 
 

--- a/endaq/device/schemata/command-response.xml
+++ b/endaq/device/schemata/command-response.xml
@@ -97,10 +97,10 @@
             2: CONFIG.UI - Read Only
             3: MANIFEST - Read Only
             4: SYSCAL - Read Only
-            5: config.cfg - Read / Write - Read requires LockID
-            6: usercal.dat - Read / Write - Read requires LockID
-            7: update.pkg - Write Only
-            8: update.pkg.sig - Write Only
+            5: config.cfg - Read / Write - requires LockID
+            6: usercal.dat - Read / Write - requires LockID
+            7: update.pkg - Write Only - requires LockID
+            8: update.pkg.sig - Write Only - requires LockID
         </IntegerElement>
         <MasterElement name="SetInfo" id="0x5B07" mandatory="0" multiple="0" >
             <IntegerElement name="InfoIndex" id="0x5B02" mandatory="1" multiple="0"> See GetInfo for index value</IntegerElement>


### PR DESCRIPTION
This implements `CommandInterface._decodeCommand()` and `CommandInterface._encodeResponse()`, for use with the upcoming MQTT Manager.

Additional changes:
* Added `CommunicationError`, to differentiate parsing/decoding and content errors from device-reported `CommandError` exceptions.
* Removed unused `destination` parameter from `updateESP32()`.
* Changed deprecated `ByteString`.