### PR TITLE
remove ncpupdatedata

### DIFF
--- a/endaq/device/schemata/flash_package.xml
+++ b/endaq/device/schemata/flash_package.xml
@@ -47,7 +47,6 @@
         <StringElement name="NcpFwRevString" id="0x87" multiple="0" mandatory="0"> NCP firmware vers. triple digit format</StringElement>
         <IntegerElement name="NcpKeySlot"  id="0x84" multiple="0" mandatory="1"> Encryption key used to decrypt NCP file</IntegerElement>
         <IntegerElement name="NcpPayloadLen" id="0x85" multiple="0" mandatory="1"> Length of NCP encrypted payload of the following format: 1 or more of (uint16 byte offset || uint16 length || [length] bytes of binary data to flash)</IntegerElement>
-        <BinaryElement name="NcpUpdateData" id="0x81" multiple="0" mandatory="1"> The binary contents of the NCP update</BinaryElement>
     </MasterElement> <!-- UpdatePkg -->
 
 </MasterElement> <!-- UpdatePkg -->


### PR DESCRIPTION
NCPUpdateData should be removed from the endaq device schema now that we decided that the update data exists outside of the EBML header