### PR TITLE
ES-657 and ES-661:  `UserDeviceName` from DEVINFO and `fromRecording()` fix

### DIFF
--- a/endaq/device/__init__.py
+++ b/endaq/device/__init__.py
@@ -33,7 +33,7 @@ logger = logging.getLogger('endaq.device')
 #
 # ============================================================================
 
-__version__ = "1.2.0"
+__version__ = "1.2.1b1"
 
 __all__ = ('CommandError', 'ConfigError', 'ConfigVersionError',
            'DeviceError', 'DeviceTimeout', 'UnsupportedFeature',

--- a/endaq/device/base.py
+++ b/endaq/device/base.py
@@ -1544,6 +1544,7 @@ class Recorder:
         dev._configData = config
 
         # Datasets merge calibration info into recorderInfo; separate them.
+        dev.getInfo()
         dev._calibration = {}
         for k in ('CalibrationDate',
                   'CalibrationExpiry',

--- a/endaq/device/base.py
+++ b/endaq/device/base.py
@@ -151,9 +151,6 @@ class Recorder:
         self.refresh(force=False)
         self.path = path
 
-        # XXX: Make sure this isn't necessary. It caused an infinite loop w/ hasInterface()
-        # self.getInfo()
-
         # The source IDE `Dataset` used for 'virtual' devices.
         self._source: Optional[Dataset] = None
 
@@ -641,7 +638,7 @@ class Recorder:
     def name(self) -> str:
         """ The recording device's (user-assigned) name. """
         try:
-            return self.config.name
+            return self.getInfo('UserDeviceName', '') or self.config.name
         except (AttributeError, KeyError, UnsupportedFeature):
             return ''
 


### PR DESCRIPTION
Two minor issues, really too small to be worth individual PRs:
* ES-661 (bug): Fixed `fromRecording()` issue introduced by DEVINO-reading changes in 1.2.0
* ES-657 (feature): Device name fetched from DEVINFO if present, falling back to getting it from config data

Also added `exclude` parameter to `importConfig()` (for future use with canned default configurations).