### PR TITLE
feature/EF-1027_upload_status_code

### DIFF
--- a/endaq/device/response_codes.py
+++ b/endaq/device/response_codes.py
@@ -24,7 +24,7 @@ class DeviceStatusCode(IntEnum):
     RESET_PENDING = 20  #: Reset pending: the device will reset soon after this response is received.
     START_PENDING = 30  #: Recording start pending: the device will start recording soon after this response is received.
     TRIGGERING = 40 #: Device is currently triggering.
-    UPLOADING = 50 #: Device is currently uploading a recording over WiFi.
+    UPLOADING = 50 #: Device is currently uploading a recording over Wi-Fi.
     SLEEPING = 100  #: Device is currently in sleep mode, or will enter sleep mode soon after this response is received. *For future use.*
 
     ERR_BUSY = -10  #: Communication channel is busy

--- a/endaq/device/response_codes.py
+++ b/endaq/device/response_codes.py
@@ -24,6 +24,7 @@ class DeviceStatusCode(IntEnum):
     RESET_PENDING = 20  #: Reset pending: the device will reset soon after this response is received.
     START_PENDING = 30  #: Recording start pending: the device will start recording soon after this response is received.
     TRIGGERING = 40 #: Device is currently triggering.
+    UPLOADING = 50 #: Device is currently uploading a recording over WiFi.
     SLEEPING = 100  #: Device is currently in sleep mode, or will enter sleep mode soon after this response is received. *For future use.*
 
     ERR_BUSY = -10  #: Communication channel is busy

--- a/endaq/device/schemata/command-response.xml
+++ b/endaq/device/schemata/command-response.xml
@@ -159,6 +159,7 @@
 		<BinaryElement name="PingReply" id="0x5701" multiple="0" mandatory="0">Serial only. Contains the echo to a Ping command.</BinaryElement>
         <IntegerElement name="DeviceStatusCode" id="0x5801" multiple="0" mandatory="0">Serial only, mandatory for serial. int16. Negative values are errors.
             100: Device is currently in sleep mode, or will enter sleep mode soon after this response is received.
+            50: Device Uploading (i.e. WiFi Upload after recording finishes)
             40: Device Triggering (i.e. waiting for a trigger)
             30: Recording start pending (device will start recording soon after this message is sent)
             20: Reset pending (device will reset soon after this message is sent)

--- a/endaq/device/schemata/command-response.xml
+++ b/endaq/device/schemata/command-response.xml
@@ -159,7 +159,7 @@
 		<BinaryElement name="PingReply" id="0x5701" multiple="0" mandatory="0">Serial only. Contains the echo to a Ping command.</BinaryElement>
         <IntegerElement name="DeviceStatusCode" id="0x5801" multiple="0" mandatory="0">Serial only, mandatory for serial. int16. Negative values are errors.
             100: Device is currently in sleep mode, or will enter sleep mode soon after this response is received.
-            50: Device Uploading (i.e. WiFi Upload after recording finishes)
+            50: Device Uploading (i.e. Wi-Fi Upload after recording finishes)
             40: Device Triggering (i.e. waiting for a trigger)
             30: Recording start pending (device will start recording soon after this message is sent)
             20: Reset pending (device will reset soon after this message is sent)


### PR DESCRIPTION
Add upload device status code, so we can differentiate between 'ready/idle' and 'upload in progress'
I have a FW build with this working, let me know if you'd like it for future testing!