### PR TITLE
Feature/es 678 clock file timeout

### DIFF
--- a/endaq/device/base.py
+++ b/endaq/device/base.py
@@ -974,8 +974,8 @@ class Recorder:
             :param epoch: If `True`, return the date/time as integer seconds
                 since the epoch ('Unix time'). If `False`, return a Python
                 `datetime.datetime` object.
-            :param timeout: Seconds to wait for a successful read, when `pause`
-                is `True`, before raising a `TimeoutError`.
+            :param timeout: Seconds to wait for successful completion before
+                raising a `TimeoutError`. Not used by older devices/firmware.
             :return: The system time and the device time. Both are UTC.
         """
         if self.isVirtual:
@@ -993,7 +993,8 @@ class Recorder:
     def setTime(self,
                 t: Union[Epoch, datetime, struct_time, tuple, None] = None,
                 pause: bool = True,
-                retries: int = 1) -> Epoch:
+                retries: int = 1,
+                timeout: Union[int, float] = 3) -> Epoch:
         """ Set a recorder's date/time. A variety of standard time types are
             accepted. Note that the minimum unit of time is the whole second.
 
@@ -1008,6 +1009,8 @@ class Recorder:
                 provided (i.e. `t` is not `None`).
             :param retries: The number of attempts to make, should the first
                 fail. Random filesystem things can potentially cause hiccups.
+            :param timeout: Seconds to wait for successful completion before
+                raising a `TimeoutError`. Not used by older devices/firmware.
             :return: The time that was set, as integer seconds since the epoch.
         """
         if self.isVirtual:
@@ -1019,7 +1022,7 @@ class Recorder:
         else:
             raise UnsupportedFeature(f'Cannot set time on device {self}')
 
-        return ci.setTime(t=t, pause=pause, retries=retries)
+        return ci.setTime(t=t, pause=pause, retries=retries, timeout=timeout)
 
 
     def getClockDrift(self,

--- a/endaq/device/base.py
+++ b/endaq/device/base.py
@@ -966,12 +966,16 @@ class Recorder:
                 for chId, subChs in channels.items()}
 
 
-    def getTime(self, epoch=True) -> Union[Tuple[datetime, datetime], Tuple[Epoch, Epoch]]:
+    def getTime(self,
+                epoch=True,
+                timeout: Union[int, float] = 3) -> Union[Tuple[datetime, datetime], Tuple[Epoch, Epoch]]:
         """ Read the date/time from the device.
 
             :param epoch: If `True`, return the date/time as integer seconds
                 since the epoch ('Unix time'). If `False`, return a Python
                 `datetime.datetime` object.
+            :param timeout: Seconds to wait for a successful read, when `pause`
+                is `True`, before raising a `TimeoutError`.
             :return: The system time and the device time. Both are UTC.
         """
         if self.isVirtual:
@@ -983,7 +987,7 @@ class Recorder:
         else:
             raise UnsupportedFeature(f'Cannot set time on device {self}')
 
-        return ci.getTime(epoch=epoch)
+        return ci.getTime(epoch=epoch, timeout=timeout)
 
 
     def setTime(self,
@@ -1020,7 +1024,8 @@ class Recorder:
 
     def getClockDrift(self,
                       pause: bool = True,
-                      retries: int =1 ) -> float:
+                      retries: int = 1,
+                      timeout: Union[int, float] = 3) -> float:
         """ Calculate how far the recorder's clock has drifted from the system
             time.
 
@@ -1030,6 +1035,8 @@ class Recorder:
                 integer seconds.
             :param retries: The number of attempts to make, should the first
                 fail. Random filesystem things can potentially cause hiccups.
+            :param timeout: Seconds to wait for a successful read, when `pause`
+                is `True`, before raising a `TimeoutError`.
             :return: The length of the drift, in seconds.
         """
         if self.isVirtual:
@@ -1041,7 +1048,7 @@ class Recorder:
         else:
             raise UnsupportedFeature(f'Cannot get time on device {self}')
 
-        return ci.getClockDrift(pause=pause, retries=retries)
+        return ci.getClockDrift(pause=pause, retries=retries, timeout=timeout)
 
 
     def _parsePolynomials(self, cal: MasterElement) -> Dict[int, Transform]:

--- a/endaq/device/linux.py
+++ b/endaq/device/linux.py
@@ -110,7 +110,7 @@ def readRecorderClock(clockFile: Filename,
             file changes (e.g. a new tick/second has started) before
             returning. This is a means to maximize accuracy.
         :param timeout: Seconds to wait for a successful read, when `pause`
-            is `True`.
+            is `True`, before raising a `TimeoutError`.
         :return: The host time, and the unparsed contents of the device clock
             file.
     """

--- a/endaq/device/win.py
+++ b/endaq/device/win.py
@@ -129,7 +129,7 @@ def readRecorderClock(clockFile: Filename,
             file changes (e.g. a new tick/second has started) before
             returning. This is a means to maximize accuracy.
         :param timeout: Seconds to wait for a successful read, when `pause`
-            is `True`.
+            is `True`, before raising a `TimeoutError`.
         :return: The host time, and the unparsed contents of the device clock
             file.
     """

--- a/endaq/device/win.py
+++ b/endaq/device/win.py
@@ -16,7 +16,7 @@ import os
 from pathlib import Path
 import sys
 from time import time
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Union
 import warnings
 
 from .types import Drive, Epoch, Filename
@@ -117,7 +117,9 @@ def readUncachedFile(filename: Filename) -> bytes:
         raise IOError(err.strerror)
 
 
-def readRecorderClock(clockFile: Filename, pause: bool = True) -> Tuple[Epoch, Epoch]:
+def readRecorderClock(clockFile: Filename,
+                      pause: bool = True,
+                      timeout: Union[int, float] = 3) -> Tuple[Epoch, Epoch]:
     """ Read a (recorder) clock file, circumventing the disk cache. Returns
         the system time and the encoded device time.
 
@@ -126,6 +128,8 @@ def readRecorderClock(clockFile: Filename, pause: bool = True) -> Tuple[Epoch, E
         :param pause: If `True` (default), wait until the data in the clock
             file changes (e.g. a new tick/second has started) before
             returning. This is a means to maximize accuracy.
+        :param timeout: Seconds to wait for a successful read, when `pause`
+            is `True`.
         :return: The host time, and the unparsed contents of the device clock
             file.
     """
@@ -152,9 +156,13 @@ def readRecorderClock(clockFile: Filename, pause: bool = True) -> Tuple[Epoch, E
     sysTime = time()
     win32file.SetFilePointer(f1, 0, win32file.FILE_BEGIN)
 
+    deadline = sysTime + timeout
+
     if pause:
         while lastTime == thisTime:
             sysTime = time()
+            if timeout > 0 and sysTime > deadline:
+                raise TimeoutError('Timed out waiting for CLOCK file to update')
             _hr, thisTime = win32file.ReadFile(f1, bpc)
             sysTime = (time() + sysTime)/2
             win32file.SetFilePointer(f1, 0, win32file.FILE_BEGIN)


### PR DESCRIPTION
* Added timeout to CLOCK 'file' reading, preventing it from hanging if the clock doesn't update. This is a workaround for a sporadic issue in which Navy S3-D16 v2 devices will read back the same data after writing to the 'file.' This could be related to Windows disk caching. Even if this is identified as a FW issue and is fixed, there could be other cases in which the clock may not update.
* Normalized clock-related methods by adding `timeout` keyword argument, so all command interfaces match. Previously, only `SerialCommandInterface` clock-related methods had `timeout`.
