### PR TITLE
Feature/dcb 74 abstract config file io

### DIFF
--- a/endaq/device/config.py
+++ b/endaq/device/config.py
@@ -1277,17 +1277,19 @@ class FileConfigInterface(ConfigInterface):
     # objects.
     # =======================================================================
 
-    @staticmethod
-    def _writefile(filename: Union[str, Path], data: bytes) -> int:
+    def _writeConfig(self, data: bytes) -> int:
         """ Open and write to a binary file. """
-        with open(filename, 'wb') as f:
+        with open(self.device.configFile, 'wb') as f:
             return f.write(data)
 
 
-    @staticmethod
-    def _readfile(filename: Union[str, Path]) -> bytes:
-        """ Open and read a binary file. """
-        with open(filename, 'rb') as f:
+    def _readConfig(self) -> bytes:
+        with open(self.device.configFile, 'rb') as f:
+            return f.read()
+
+
+    def _readUi(self):
+        with open(self.device.configUIFile, 'rb') as f:
             return f.read()
 
 
@@ -1400,8 +1402,7 @@ class FileConfigInterface(ConfigInterface):
         """
         if not self.configUi:
             if self._isfile(self.device.configUIFile):
-                ui = self._readfile(self.device.configUIFile)
-                self.configUi = self._schema.loads(ui)
+                self.configUi = self._schema.loads(self._readUi())
             else:
                 ebml = ui_defaults.getDefaultConfigUI(self.device)
                 if not ebml:
@@ -1420,7 +1421,7 @@ class FileConfigInterface(ConfigInterface):
             return None
 
         try:
-            data = self._readfile(self.device.configFile)
+            data = self._readConfig()
             if data:
                 return loadSchema('mide_ide.xml').loads(data)
 
@@ -1483,7 +1484,7 @@ class FileConfigInterface(ConfigInterface):
 
         try:
             self._makeBackup(self.device.configFile)
-            self._writefile(self.device.configFile, configEbml)
+            self._writeConfig(configEbml)
 
             if clear:
                 for item in self.items.values():

--- a/endaq/device/config.py
+++ b/endaq/device/config.py
@@ -1301,17 +1301,15 @@ class FileConfigInterface(ConfigInterface):
         return os.path.isfile(filename)
 
 
-    @staticmethod
-    def _makeBackup(filename: Union[str, Path]) -> bool:
-        """ Create a backup copy of the given file. """
-        return util.makeBackup(filename)
+    def _backupConfig(self) -> bool:
+        """ Create a backup copy of the device's config file. """
+        return util.makeBackup(self.device.configFile)
 
 
-    @staticmethod
-    def _restoreBackup(filename: Union[str, Path],
+    def _restoreConfig(self,
                        remove: bool = False) -> bool:
-        """ Restore a backup copy of a file, overwriting the file. """
-        return util.restoreBackup(filename, remove)
+        """ Restore a backup copy of the device's config file. """
+        return util.restoreBackup(self.device.configFile, remove)
 
 
     # =======================================================================
@@ -1483,7 +1481,7 @@ class FileConfigInterface(ConfigInterface):
         configEbml = loadSchema('mide_ide.xml').encodes(config, headers=False)
 
         try:
-            self._makeBackup(self.device.configFile)
+            self._backupConfig()
             self._writeConfig(configEbml)
 
             if clear:
@@ -1492,7 +1490,7 @@ class FileConfigInterface(ConfigInterface):
 
         except Exception:
             # Write failed, restore old config file
-            self._restoreBackup(self.device.configFile, remove=False)
+            self._restoreConfig(remove=False)
             raise
 
 

--- a/endaq/device/config.py
+++ b/endaq/device/config.py
@@ -1278,17 +1278,19 @@ class FileConfigInterface(ConfigInterface):
     # =======================================================================
 
     def _writeConfig(self, data: bytes) -> int:
-        """ Open and write to a binary file. """
+        """ Open and write to the device's config file. """
         with open(self.device.configFile, 'wb') as f:
             return f.write(data)
 
 
     def _readConfig(self) -> bytes:
+        """ Open and read the device's config file. """
         with open(self.device.configFile, 'rb') as f:
             return f.read()
 
 
     def _readUi(self):
+        """ Open and read the device's `CONFIG.UI` file. """
         with open(self.device.configUIFile, 'rb') as f:
             return f.read()
 
@@ -1301,16 +1303,14 @@ class FileConfigInterface(ConfigInterface):
 
     @staticmethod
     def _makeBackup(filename: Union[str, Path]) -> bool:
-        """ Create a backup copy of the given file.
-        """
+        """ Create a backup copy of the given file. """
         return util.makeBackup(filename)
 
 
     @staticmethod
     def _restoreBackup(filename: Union[str, Path],
                        remove: bool = False) -> bool:
-        """ Restore a backup copy of a file, overwriting the file.
-        """
+        """ Restore a backup copy of a file, overwriting the file. """
         return util.restoreBackup(filename, remove)
 
 

--- a/endaq/device/config.py
+++ b/endaq/device/config.py
@@ -1278,14 +1278,14 @@ class FileConfigInterface(ConfigInterface):
     # =======================================================================
 
     @staticmethod
-    def _writeFile(filename: Union[str, Path], data: bytes) -> int:
+    def _writefile(filename: Union[str, Path], data: bytes) -> int:
         """ Open and write to a binary file. """
         with open(filename, 'wb') as f:
             return f.write(data)
 
 
     @staticmethod
-    def _readFile(filename: Union[str, Path]) -> bytes:
+    def _readfile(filename: Union[str, Path]) -> bytes:
         """ Open and read a binary file. """
         with open(filename, 'rb') as f:
             return f.read()
@@ -1400,7 +1400,7 @@ class FileConfigInterface(ConfigInterface):
         """
         if not self.configUi:
             if self._isfile(self.device.configUIFile):
-                ui = self._readFile(self.device.configUIFile)
+                ui = self._readfile(self.device.configUIFile)
                 self.configUi = self._schema.loads(ui)
             else:
                 ebml = ui_defaults.getDefaultConfigUI(self.device)
@@ -1420,7 +1420,7 @@ class FileConfigInterface(ConfigInterface):
             return None
 
         try:
-            data = self._readFile(self.device.configFile)
+            data = self._readfile(self.device.configFile)
             if data:
                 return loadSchema('mide_ide.xml').loads(data)
 
@@ -1483,7 +1483,7 @@ class FileConfigInterface(ConfigInterface):
 
         try:
             self._makeBackup(self.device.configFile)
-            self._writeFile(self.device.configFile, configEbml)
+            self._writefile(self.device.configFile, configEbml)
 
             if clear:
                 for item in self.items.values():


### PR DESCRIPTION
This abstracts the actual file I/O and filesystem-related function calls in `FileConfigInterface` to allow the upcoming remote configuration subclass to reuse more code.

This is a minor change, but I wanted to get it into `develop` before the bigger MQTT PRs.