### PR TITLE
Changed EBML `DocType` to match schema filenames/naming conventions

### DIFF
--- a/endaq/device/schemata/command-response.xml
+++ b/endaq/device/schemata/command-response.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Schema type="mide.ss.cmd" version="3" readversion="2">
+<Schema type="mide_command_response" version="3" readversion="2">
     <SchemaInfo>
         <Author>Derek Witt</Author>
         <Author>David Randall Stokes</Author>
@@ -12,7 +12,7 @@
         <UIntegerElement name="EBMLReadVersion" id="0x42F7" multiple="0" mandatory="1" default="1" minver="1">The minimum EBML version a parser has to support to read this file.</UIntegerElement>
         <UIntegerElement name="EBMLMaxIDLength" id="0x42F2" multiple="0" mandatory="1" default="4" minver="1">The maximum length of the IDs you'll find in this file (4 or less in Matroska).</UIntegerElement>
         <UIntegerElement name="EBMLMaxSizeLength" id="0x42F3" multiple="0" mandatory="1" default="8" minver="1">The maximum length of the sizes you'll find in this file (8 or less in Matroska). This does not override the element size indicated at the beginning of an element. Elements that have an indicated size which is larger than what is allowed by EBMLMaxSizeLength shall be considered invalid.</UIntegerElement>
-        <StringElement name="DocType" id="0x4282" multiple="0" mandatory="1" default="mide.ss.cmd" minver="1">A string that describes the type of document that follows this EBML header. This describes a firmware package</StringElement>
+        <StringElement name="DocType" id="0x4282" multiple="0" mandatory="1" default="mide_command_response" minver="1">A string that describes the type of document that follows this EBML header. This describes a firmware package</StringElement>
         <UIntegerElement name="DocTypeVersion" id="0x4287" multiple="0" mandatory="1" default="1" minver="1">The version of DocType interpreter used to create the file.</UIntegerElement>
         <UIntegerElement name="DocTypeReadVersion" id="0x4285" multiple="0" mandatory="1" default="1" minver="1">The minimum DocType version an interpreter has to support to read this file.</UIntegerElement>
         <BinaryElement name="Void" global="1" id="0xEC" multiple="1" minver="1">Used to void damaged data, to avoid unexpected behaviors when using damaged data. The content is discarded. Also used to reserve space in a sub-element for later use.</BinaryElement>

--- a/endaq/device/schemata/flash_package.xml
+++ b/endaq/device/schemata/flash_package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Schema type="mide.ss.fwpkg" version="3" readversion="2">
+<Schema type="mide_flash_package" version="3" readversion="2">
     <SchemaInfo>
         <Author>Derek Witt</Author>
         <Description>Metadata and packing format for encrypted update packages</Description>
@@ -11,7 +11,7 @@
         <UIntegerElement name="EBMLReadVersion" id="0x42F7" multiple="0" mandatory="1" default="1" minver="1">The minimum EBML version a parser has to support to read this file.</UIntegerElement>
         <UIntegerElement name="EBMLMaxIDLength" id="0x42F2" multiple="0" mandatory="1" default="4" minver="1">The maximum length of the IDs you'll find in this file (4 or less in Matroska).</UIntegerElement>
         <UIntegerElement name="EBMLMaxSizeLength" id="0x42F3" multiple="0" mandatory="1" default="8" minver="1">The maximum length of the sizes you'll find in this file (8 or less in Matroska). This does not override the element size indicated at the beginning of an element. Elements that have an indicated size which is larger than what is allowed by EBMLMaxSizeLength shall be considered invalid.</UIntegerElement>
-        <StringElement name="DocType" id="0x4282" multiple="0" mandatory="1" default="mide.ss.fwpkg" minver="1">A string that describes the type of document that follows this EBML header. This describes a firmware package</StringElement>
+        <StringElement name="DocType" id="0x4282" multiple="0" mandatory="1" default="mide_flash_package" minver="1">A string that describes the type of document that follows this EBML header. This describes a firmware package</StringElement>
         <UIntegerElement name="DocTypeVersion" id="0x4287" multiple="0" mandatory="1" default="1" minver="1">The version of DocType interpreter used to create the file.</UIntegerElement>
         <UIntegerElement name="DocTypeReadVersion" id="0x4285" multiple="0" mandatory="1" default="1" minver="1">The minimum DocType version an interpreter has to support to read this file.</UIntegerElement>
         <BinaryElement name="Void" global="1" id="0xEC" multiple="1" minver="1">Used to void damaged data, to avoid unexpected behaviors when using damaged data. The content is discarded. Also used to reserve space in a sub-element for later use.</BinaryElement>

--- a/endaq/device/schemata/mide_config_ui.xml
+++ b/endaq/device/schemata/mide_config_ui.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Schema type="mide.ss.config" version="2" readversion="2">
+<Schema type="mide_config_ui" version="2" readversion="2">
     <SchemaInfo>
         <Author>David Stokes, Peter Scheidler</Author>
         <Description>Schema for the device-produced data used to define the user interface for configuring an enDAQ data recorder.</Description>
@@ -11,7 +11,7 @@
         <UIntegerElement name="EBMLReadVersion" id="0x42F7" multiple="0" mandatory="1" default="1" minver="1">The minimum EBML version a parser has to support to read this file.</UIntegerElement>
         <UIntegerElement name="EBMLMaxIDLength" id="0x42F2" multiple="0" mandatory="1" default="4" minver="1">The maximum length of the IDs you'll find in this file (4 or less in Matroska).</UIntegerElement>
         <UIntegerElement name="EBMLMaxSizeLength" id="0x42F3" multiple="0" mandatory="1" default="8" minver="1">The maximum length of the sizes you'll find in this file (8 or less in Matroska). This does not override the element size indicated at the beginning of an element. Elements that have an indicated size which is larger than what is allowed by EBMLMaxSizeLength shall be considered invalid.</UIntegerElement>
-        <StringElement name="DocType" id="0x4282" multiple="0" mandatory="1" default="mide.ss.config" minver="1">A string that describes the type of document that follows this EBML header. 'mide' for Mide Instrumentation Data Exchange files.</StringElement>
+        <StringElement name="DocType" id="0x4282" multiple="0" mandatory="1" default="mide_config_ui" minver="1">A string that describes the type of document that follows this EBML header. 'mide' for Mide Instrumentation Data Exchange files.</StringElement>
         <UIntegerElement name="DocTypeVersion" id="0x4287" multiple="0" mandatory="1" default="1" minver="1">The version of DocType interpreter used to create the file.</UIntegerElement>
         <UIntegerElement name="DocTypeReadVersion" id="0x4285" multiple="0" mandatory="1" default="1" minver="1">The minimum DocType version an interpreter has to support to read this file.</UIntegerElement>
         <BinaryElement name="Void" global="1" id="0xEC" multiple="1" minver="1">Used to void damaged data, to avoid unexpected behaviors when using damaged data. The content is discarded. Also used to reserve space in a sub-element for later use.</BinaryElement>

--- a/endaq/device/schemata/mide_manifest.xml
+++ b/endaq/device/schemata/mide_manifest.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Schema type="mide" version="3" readversion="2">
+<Schema type="endaq_manifest" version="3" readversion="2">
   <!-- Base EBML elements. Required. -->
   <MasterElement name="EBML" id="0x1A45DFA3" mandatory="1" multiple="0" minver="1">Set the EBML characteristics of the data to follow. Each EBML document has to start with this.
       <UIntegerElement name="EBMLVersion" id="0x4286" multiple="0" mandatory="1" default="1" minver="1">The version of EBML parser used to create the file.</UIntegerElement>
       <UIntegerElement name="EBMLReadVersion" id="0x42F7" multiple="0" mandatory="1" default="1" minver="1">The minimum EBML version a parser has to support to read this file.</UIntegerElement>
       <UIntegerElement name="EBMLMaxIDLength" id="0x42F2" multiple="0" mandatory="1" default="4" minver="1">The maximum length of the IDs you'll find in this file (4 or less in Matroska).</UIntegerElement>
       <UIntegerElement name="EBMLMaxSizeLength" id="0x42F3" multiple="0" mandatory="1" default="8" minver="1">The maximum length of the sizes you'll find in this file (8 or less in Matroska). This does not override the element size indicated at the beginning of an element. Elements that have an indicated size which is larger than what is allowed by EBMLMaxSizeLength shall be considered invalid.</UIntegerElement>
-      <StringElement name="DocType" id="0x4282" multiple="0" mandatory="1" default="mide" minver="1">A string that describes the type of document that follows this EBML header. 'mide' for Mide Instrumentation Data Exchange files.</StringElement>
+      <StringElement name="DocType" id="0x4282" multiple="0" mandatory="1" default="endaq_management" minver="1">A string that describes the type of document that follows this EBML header. 'mide' for Mide Instrumentation Data Exchange files.</StringElement>
       <UIntegerElement name="DocTypeVersion" id="0x4287" multiple="0" mandatory="1" default="2" minver="1">The version of DocType interpreter used to create the file.</UIntegerElement>
       <UIntegerElement name="DocTypeReadVersion" id="0x4285" multiple="0" mandatory="1" default="2" minver="1">The minimum DocType version an interpreter has to support to read this file.</UIntegerElement>
       <BinaryElement name="Void" global="1" id="0xEC" multiple="1" minver="1">Used to void damaged data, to avoid unexpected behaviors when using damaged data. The content is discarded. Also used to reserve space in a sub-element for later use.</BinaryElement>

--- a/endaq/device/schemata/mide_manifest.xml
+++ b/endaq/device/schemata/mide_manifest.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Schema type="endaq_manifest" version="3" readversion="2">
+<Schema type="mide_manifest" version="3" readversion="2">
   <!-- Base EBML elements. Required. -->
   <MasterElement name="EBML" id="0x1A45DFA3" mandatory="1" multiple="0" minver="1">Set the EBML characteristics of the data to follow. Each EBML document has to start with this.
       <UIntegerElement name="EBMLVersion" id="0x4286" multiple="0" mandatory="1" default="1" minver="1">The version of EBML parser used to create the file.</UIntegerElement>
       <UIntegerElement name="EBMLReadVersion" id="0x42F7" multiple="0" mandatory="1" default="1" minver="1">The minimum EBML version a parser has to support to read this file.</UIntegerElement>
       <UIntegerElement name="EBMLMaxIDLength" id="0x42F2" multiple="0" mandatory="1" default="4" minver="1">The maximum length of the IDs you'll find in this file (4 or less in Matroska).</UIntegerElement>
       <UIntegerElement name="EBMLMaxSizeLength" id="0x42F3" multiple="0" mandatory="1" default="8" minver="1">The maximum length of the sizes you'll find in this file (8 or less in Matroska). This does not override the element size indicated at the beginning of an element. Elements that have an indicated size which is larger than what is allowed by EBMLMaxSizeLength shall be considered invalid.</UIntegerElement>
-      <StringElement name="DocType" id="0x4282" multiple="0" mandatory="1" default="endaq_management" minver="1">A string that describes the type of document that follows this EBML header. 'mide' for Mide Instrumentation Data Exchange files.</StringElement>
+      <StringElement name="DocType" id="0x4282" multiple="0" mandatory="1" default="mide_manifest" minver="1">A string that describes the type of document that follows this EBML header. 'mide' for Mide Instrumentation Data Exchange files.</StringElement>
       <UIntegerElement name="DocTypeVersion" id="0x4287" multiple="0" mandatory="1" default="2" minver="1">The version of DocType interpreter used to create the file.</UIntegerElement>
       <UIntegerElement name="DocTypeReadVersion" id="0x4285" multiple="0" mandatory="1" default="2" minver="1">The minimum DocType version an interpreter has to support to read this file.</UIntegerElement>
       <BinaryElement name="Void" global="1" id="0xEC" multiple="1" minver="1">Used to void damaged data, to avoid unexpected behaviors when using damaged data. The content is discarded. Also used to reserve space in a sub-element for later use.</BinaryElement>


### PR DESCRIPTION
The `DocType` names in the schemata have been modified to either match or follow the conventions of the schema filenames. This is to allow (semi-) automatic schema detection when opening files, with a minimum of special-casing. 

I'd rather have named them `endaq_*`, but half the filenames started `mide_*`, so that would be a greater change. Existing code doesn't use the `DocType`, only filenames.