### PR TITLE
Feature/add system state code

### DIFF
--- a/endaq/device/schemata/command-response.xml
+++ b/endaq/device/schemata/command-response.xml
@@ -163,8 +163,7 @@
         </UIntegerElement>
 		<BinaryElement name="PingReply" id="0x5701" multiple="0" mandatory="0">Serial only. Contains the echo to a Ping command.</BinaryElement>
         <IntegerElement name="DeviceStatusCode" id="0x5801" multiple="0" mandatory="0">Serial only, mandatory for serial. int16. Negative values are errors.
-            200: Device Resetting
-            110: Device Wireless Interface is in low-power mode 
+            110: Command Interface Offline (e.g. Device Wireless Interface in Low Power mode, etc.)
             100: Device is currently in sleep mode, or will enter sleep mode soon after this response is received.
             50: Device Uploading (i.e. Wi-Fi Upload after recording finishes)
             40: Device Triggering (i.e. waiting for a trigger)

--- a/endaq/device/schemata/command-response.xml
+++ b/endaq/device/schemata/command-response.xml
@@ -211,13 +211,13 @@
         <IntegerElement name="SystemStateCode" id="0x5D01" multiple="0" mandatory="0"> System state of device unaffected by command errors. Values match those in Device Status Code.
             110: Command Interface is currently offline (for reason other than sleep)  
             100: Device is currently in sleep mode
-            50: Device Uploading (i.e. Wi-Fi Upload after recording finishes)
+            50: Device Uploading
             40: Device Triggering (i.e. waiting for a trigger)
-            30: Recording start pending (device will start recording soon after this message is sent)
-            20: Reset pending (device will reset soon after this message is sent)
+            30: Recording starting
+            20: Device resetting
             10: Device recording
             1: Device idle, unmounted.
-            0: Device idle, message successful. It is presumed the device is mounted as an MSD.
+            0: Device idle. It is presumed the device is mounted as an MSD.
         </IntegerElement>
         <UnicodeElement name="SystemStateMessage" id="0x5E01" multiple="0" mandatory="0">Optional code for system state</UnicodeElement>
 

--- a/endaq/device/schemata/command-response.xml
+++ b/endaq/device/schemata/command-response.xml
@@ -206,6 +206,21 @@
             <UIntegerElement name="SerialNumber" id="0x5C12" multiple="0" mandatory="1"/>
             <BinaryElement name="IDEHeaderData" id="0x5C31" multiple="0" mandatory="1"/>
         </MasterElement>
+
+        <IntegerElement name="SystemStateCode" id="0x5D01" multiple="0" mandatory="0"> System state of device unaffected by command errors. Values match those in Device Status Code.
+            200: Device Resetting
+            110: Device Wireless Interface is in low-power mode 
+            100: Device is currently in sleep mode, or will enter sleep mode soon after this response is received.
+            50: Device Uploading (i.e. Wi-Fi Upload after recording finishes)
+            40: Device Triggering (i.e. waiting for a trigger)
+            30: Recording start pending (device will start recording soon after this message is sent)
+            20: Reset pending (device will reset soon after this message is sent)
+            10: Device recording
+            1: Device idle, unmounted.
+            0: Device idle, message successful. It is presumed the device is mounted as an MSD.
+        </IntegerElement>
+        <UnicodeElement name="SystemStateMessage" id="0x5E01" multiple="0" mandatory="0">Optional code for system state</UnicodeElement>
+
     </MasterElement>
 
 <!--

--- a/endaq/device/schemata/command-response.xml
+++ b/endaq/device/schemata/command-response.xml
@@ -163,6 +163,8 @@
         </UIntegerElement>
 		<BinaryElement name="PingReply" id="0x5701" multiple="0" mandatory="0">Serial only. Contains the echo to a Ping command.</BinaryElement>
         <IntegerElement name="DeviceStatusCode" id="0x5801" multiple="0" mandatory="0">Serial only, mandatory for serial. int16. Negative values are errors.
+            200: Device Resetting
+            110: Device Wireless Interface is in low-power mode 
             100: Device is currently in sleep mode, or will enter sleep mode soon after this response is received.
             50: Device Uploading (i.e. Wi-Fi Upload after recording finishes)
             40: Device Triggering (i.e. waiting for a trigger)
@@ -208,8 +210,6 @@
         </MasterElement>
 
         <IntegerElement name="SystemStateCode" id="0x5D01" multiple="0" mandatory="0"> System state of device unaffected by command errors. Values match those in Device Status Code.
-            200: Device Resetting
-            110: Device Wireless Interface is in low-power mode 
             100: Device is currently in sleep mode, or will enter sleep mode soon after this response is received.
             50: Device Uploading (i.e. Wi-Fi Upload after recording finishes)
             40: Device Triggering (i.e. waiting for a trigger)

--- a/endaq/device/schemata/command-response.xml
+++ b/endaq/device/schemata/command-response.xml
@@ -163,7 +163,7 @@
         </UIntegerElement>
 		<BinaryElement name="PingReply" id="0x5701" multiple="0" mandatory="0">Serial only. Contains the echo to a Ping command.</BinaryElement>
         <IntegerElement name="DeviceStatusCode" id="0x5801" multiple="0" mandatory="0">Serial only, mandatory for serial. int16. Negative values are errors.
-            110: Command Interface Offline (e.g. Device Wireless Interface in Low Power mode, etc.)
+            110: Command Interface is going (or is currently) offline (for reason other than sleep)
             100: Device is currently in sleep mode, or will enter sleep mode soon after this response is received.
             50: Device Uploading (i.e. Wi-Fi Upload after recording finishes)
             40: Device Triggering (i.e. waiting for a trigger)
@@ -209,7 +209,8 @@
         </MasterElement>
 
         <IntegerElement name="SystemStateCode" id="0x5D01" multiple="0" mandatory="0"> System state of device unaffected by command errors. Values match those in Device Status Code.
-            100: Device is currently in sleep mode, or will enter sleep mode soon after this response is received.
+            110: Command Interface is currently offline (for reason other than sleep)  
+            100: Device is currently in sleep mode
             50: Device Uploading (i.e. Wi-Fi Upload after recording finishes)
             40: Device Triggering (i.e. waiting for a trigger)
             30: Recording start pending (device will start recording soon after this message is sent)


### PR DESCRIPTION
Looking to separate the command errors from the system state following https://midetech.atlassian.net/wiki/spaces/EC/pages/2598895626/Proposal+Separating+command+errors+from+system+state. The idea here is to add another EBML element in responses that just contains the state of a sensor and does not factor in errors that may have occurred during command reception+processing. 

This will also allow us to handle the situation where the sensor's wireless interface is put into low power modes but the device is still in the triggering or recording states. Previously, only one value was included so when the device would publish a sleeping state message when triggering/recording, that could easily be taken as the triggers were stopped and the device is no longer in the triggering state. With these updates remote devices interested in the state of the sensor could see that the response state might be wireless low power, but the overall state is still triggering.

Also, please let me know if you having naming suggestions :)