### PR TITLE
New Manifest Element for Deep Sleep wakeup pins

### DIFF
--- a/endaq/device/schemata/mide_manifest.xml
+++ b/endaq/device/schemata/mide_manifest.xml
@@ -176,6 +176,7 @@
         <MasterElement name="DigitalLedThree" id="0x4DD2" mandatory="0" multiple="0" minver="1">Indicates that the membrane has a 3rd LED driven by the MCU.</MasterElement>
         <MasterElement name="DigitalSensorSI1133" id="0x4DD3" mandatory="0" multiple="0" minver="1">Indicates the presence of a SI1133 light sensor on the I2C1 bus.</MasterElement>
         <MasterElement name="UseLegacyUserInterface" id="0x4DD7" mandatory="0" multiple="0" minver="1">Indicates that the device should be displaing the legacy UI.</MasterElement>
+        <MasterElement name="DeepSleepWakeupPins" id="0x4DD8" mandatory="0" multiple="0" minver="1">Indicates that the device has proper wakeup pins for lowest possible sleep level.</MasterElement>
 
         <!-- Analog Out -->
         <MasterElement name="PeripheralHeater" id="0x4F00" mandatory="0" multiple="0" minver="1">Indicates the presence of an analog heater device.


### PR DESCRIPTION
This new manifest element will apply for all H devices and for future S+W board revisions which use the proper wakeup pins to allow for lowest possible sleep levels.