### PR TITLE
Improved simple command response check; added start at time config

### DIFF
--- a/endaq/device/command_interfaces.py
+++ b/endaq/device/command_interfaces.py
@@ -3,7 +3,6 @@ Command interfaces: the mechanisms that communicate with
 and control the recording device.
 """
 
-import calendar
 from copy import deepcopy
 from datetime import datetime
 import errno
@@ -31,6 +30,7 @@ from .exceptions import CRCError
 from .types import Epoch, Filename
 from . import response_codes
 from .response_codes import *
+from . import util
 
 if sys.platform == 'darwin':
     from . import macos as os_specific
@@ -407,12 +407,7 @@ class CommandInterface:
         """
         if t is not None:
             pause = False
-            if isinstance(t, datetime):
-                t = calendar.timegm(t.timetuple())
-            elif isinstance(t, (struct_time, tuple)):
-                t = calendar.timegm(t)
-            else:
-                t = int(t)
+            t = util.time2epoch(t)
 
         with self.device._busy:
             try:
@@ -516,7 +511,7 @@ class CommandInterface:
 
     def _runSimpleCommand(self,
                           cmd: dict,
-                          statusCode: int = DeviceStatusCode.RESET_PENDING,
+                          statusCode: Union[None, int, List[int]] = DeviceStatusCode.RESET_PENDING,
                           timeoutMsg: Optional[str] = None,
                           wait: bool = True,
                           timeout: Union[int, float] = 5,
@@ -527,8 +522,10 @@ class CommandInterface:
             expected/required.
 
             :param cmd: The command to execute.
-            :param statusCode: The ``<CommandResponseCode>`` expected in the
-                acknowledgement (if the interface supports one).
+            :param statusCode: A ``<CommandResponseCode>`` values expected in
+                the acknowledgement (if the interface supports one). May also
+                be a list if success could generate different responses (e.g.,
+                in different firmware versions).
             :param wait: If `True`, wait for the recorer to respond and/or
                 dismount.
             :param timeout: Time (in seconds) to wait for a response before
@@ -540,15 +537,21 @@ class CommandInterface:
                 require no arguments.
             :returns: `True` if the command was successful.
         """
+        if not isinstance(statusCode, (list, tuple)) or statusCode is None:
+            statusCode = [statusCode]
+
         if self.device.isRemote:
             wait = False
 
+        lastStatus = self.status[0]
         self._sendCommand(cmd, response=False, timeout=0.1, callback=callback)
 
         # Since no response is expected, a failure to read a response caused
         # by the device resetting will just set self.status to (None, None).
         # Success is self.status[1] == None or the expected status code.
-        if self.response[1] is not None and self.response[1] != statusCode:
+        if (statusCode is not None
+                and self.response[0] != lastStatus
+                and self.response[1] not in statusCode):
             return False
 
         if wait:

--- a/endaq/device/command_interfaces.py
+++ b/endaq/device/command_interfaces.py
@@ -537,7 +537,7 @@ class CommandInterface:
                 require no arguments.
             :returns: `True` if the command was successful.
         """
-        if not isinstance(statusCode, (list, tuple)) or statusCode is None:
+        if not isinstance(statusCode, (list, tuple)) and statusCode is not None:
             statusCode = [statusCode]
 
         if self.device.isRemote:

--- a/endaq/device/config.py
+++ b/endaq/device/config.py
@@ -9,10 +9,12 @@ device's realtime clock is also done through the command interface, as it
 also takes effect immediately.
 """
 
+from datetime import datetime
 import errno
 import logging
 import os.path
 from pathlib import Path
+from time import struct_time
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 import warnings
 
@@ -21,6 +23,7 @@ from ebmlite.core import Document, MasterElement, UnknownElement
 from idelib.dataset import Channel, SubChannel
 
 from .exceptions import ConfigError, DeviceError, UnsupportedFeature
+from .types import Epoch
 from . import legacy
 from . import ui_defaults
 from . import util
@@ -46,6 +49,7 @@ _POST_CONFIG_MSG = ("When ready...\n"
                     "    1. Disconnect the recorder\n"
                     "    2. Mount to surface\n"
                     "    3. Press the recorder's primary button ")
+
 
 # ===========================================================================
 #
@@ -275,7 +279,7 @@ class ConfigItem:
         if not isinstance(exp, str):
             # Probably won't occur, but just in case...
             logger.debug("Ignoring bad value for {}: {!r} ({})".format(idstr, exp, type(exp)))
-            return
+            return None
 
         try:
             return compile(exp, "<{}>".format(msg), "eval")
@@ -372,6 +376,7 @@ class ConfigItem:
         """ The configuration item's default value. """
         if self._default:
             return eval(self._valueFormat, {'x': self._default})
+        return None
 
 
     @property
@@ -927,7 +932,8 @@ class ConfigInterface:
 
     @property
     def recordingDir(self) -> Union[str, None]:
-        """ The name of the directory (on the device) where recordings are saved. """
+        """ The name of the directory (on the device) where recordings are saved.
+        """
         return self._getitem(0x14ff7f).value
 
     @recordingDir.setter
@@ -944,6 +950,27 @@ class ConfigInterface:
         self._setitem(0x15ff7f, prefix)
 
     @property
+    def recordingStartTime(self) -> Union[datetime, None]:
+        """ Date/time at which the recording will start. If trigger
+            conditions have been set, this determines when they will start
+            being checked.
+        """
+        t = self._getitem(0x0fff7f).value
+        if t is None:
+            return None
+        return datetime.utcfromtimestamp(t)
+
+    @recordingStartTime.setter
+    def recordingStartTime(self, t: Union[Epoch, datetime, struct_time, tuple, None]):
+        """ Delay before starting a recording, including between recordings
+            if 'Retrigger' is checked.
+        """
+        if t is not None:
+            t = util.time2epoch(t)
+
+        self._setitem(0x0fff7f, t)
+
+    @property
     def recordingTimeLimit(self) -> Union[int, None]:
         return self._getitem(0x0dff7f).value
 
@@ -953,6 +980,7 @@ class ConfigInterface:
 
     @property
     def recordingSizeLimit(self) -> Union[int, None]:
+        """ The maximum size of a single recording file (in bytes). """
         return self._getitem(0x11ff7f).value
 
     @recordingSizeLimit.setter

--- a/endaq/device/util.py
+++ b/endaq/device/util.py
@@ -2,11 +2,13 @@
 Some basic utility functions, for internal use.
 """
 
+import calendar
+from datetime import datetime
 import errno
 import os.path
 import pathlib
 import shutil
-from typing import Any,ByteString, Dict, Union
+from typing import Any, ByteString, Dict, Union
 
 import logging
 logger = logging.getLogger(__name__)
@@ -78,3 +80,16 @@ def dump(data: ByteString, length: int = 8) -> str:
     if not length:
         length = len(data)
     return ' '.join(f'{x:02x}' for x in data[:length])
+
+
+def time2epoch(t: Union[int, float, datetime, tuple]) -> int:
+    """ Convenient function to convert any of several representations
+        of time (`datetime`, timestamps, time struct, etc.) into
+        integer UNIX epoch timestamps.
+    """
+    if isinstance(t, datetime):
+        return calendar.timegm(t.timetuple())
+    elif isinstance(t, tuple):
+        return calendar.timegm(t)
+    else:
+        return int(t)


### PR DESCRIPTION
* Simple commands (`startRecording()`, `reset()`) should no longer erroneously return `False` depending on what was called before them. 
* The 'start at time' trigger now has a property (R/W) in `ConfigInterface`.