### PR TITLE
Feature/es 815 get status

### DIFF
--- a/endaq/device/base.py
+++ b/endaq/device/base.py
@@ -43,6 +43,7 @@ from . import command_interfaces
 from .command_interfaces import CommandInterface
 from .exceptions import *
 from .types import Drive, Filename, Epoch
+from . import util
 
 logger = logging.getLogger(__name__)
 
@@ -791,7 +792,8 @@ class Recorder:
         """ The recorder's date of manufacture. """
         bd = self.getInfo('DateOfManufacture')
         if bd is not None:
-            return datetime.utcfromtimestamp(bd)
+            return util.utcfromtimestamp(bd)
+        return None
 
     
     @property
@@ -1069,7 +1071,7 @@ class Recorder:
         return ci.getClockDrift(pause=pause, retries=retries, timeout=timeout)
 
 
-    def _parsePolynomials(self, cal: MasterElement) -> Dict[int, Transform]:
+    def _parsePolynomials(self, cal: MasterElement) -> Optional[Dict[int, Transform]]:
         """ Helper method to parse CalibrationList EBML into `Transform`
             objects.
         """
@@ -1081,7 +1083,7 @@ class Recorder:
             return calPolys
         except (KeyError, IndexError, ValueError) as err:
             logger.debug("_parsePolynomials() raised a possibly-allowed exception: %r" % err)
-            pass
+            return None
 
 
     def getManifest(self) -> Union[Dict[str, Any], None]:
@@ -1237,7 +1239,7 @@ class Recorder:
         if data:
             cd = data.get('CalibrationDate', None)
             if cd is not None and not epoch:
-                return datetime.utcfromtimestamp(cd)
+                return util.utcfromtimestamp(cd)
             return cd
         return None
 
@@ -1274,7 +1276,7 @@ class Recorder:
         """
         ce = self._getCalExpiration(self.getCalibration(user=user))
         if ce is not None and not epoch:
-            return datetime.utcfromtimestamp(ce)
+            return util.utcfromtimestamp(ce)
         return ce
 
 

--- a/endaq/device/command_interfaces.py
+++ b/endaq/device/command_interfaces.py
@@ -48,7 +48,6 @@ if TYPE_CHECKING:
 #
 # ===========================================================================
 
-
 class CommandInterface:
     """
     Base class for command interfaces, the mechanism that communicates with
@@ -258,12 +257,12 @@ class CommandInterface:
                 in place, but as a convenience, it is also returned).
         """
         if not response:
-            return
+            return None
 
         for name, code in [(k, v) for k, v in response.items()
-                           if k in response_codes.__dict__]:
+                           if k in vars(response_codes)]:
             try:
-                response[name] = response_codes.__dict__[name](code)
+                response[name] = vars(response_codes)[name](code)
             except (AttributeError, TypeError, ValueError):
                 logger.debug('Received unknown {}: {}'.format(name, code))
                 pass
@@ -376,8 +375,8 @@ class CommandInterface:
         if epoch:
             return sysTime, devTime
 
-        return (datetime.utcfromtimestamp(sysTime),
-                datetime.utcfromtimestamp(devTime))
+        return (util.utcfromtimestamp(sysTime),
+                util.utcfromtimestamp(devTime))
 
 
     def setTime(self,
@@ -1062,7 +1061,7 @@ class CommandInterface:
         with self.device._busy:
             self.setWifi(cmd, timeout=timeout, callback=callback)
             if not wait or timeout == 0:
-                return
+                return None
 
             while timeout < 0 or time() < deadline:
                 if callback is not None and callback():
@@ -1072,7 +1071,7 @@ class CommandInterface:
                 if response:
                     status = response.get('WiFiConnectionStatus')
                     if status == WiFiConnectionStatus.CONNECTED:
-                        return
+                        return None
                 else:
                     logger.debug('setAP(): got bad queryWifi() response: {!r}'
                                  .format(response))
@@ -1224,7 +1223,7 @@ class CommandInterface:
 
                 aps.append(defaults)
 
-            return aps
+        return aps
 
 
     def updateESP32(self,
@@ -1659,6 +1658,8 @@ class SerialCommandInterface(CommandInterface):
             if sn == devSerial:
                 return port
 
+        return None
+
 
     def getSerialPort(self,
                       reset: bool = False,
@@ -1915,7 +1916,7 @@ class SerialCommandInterface(CommandInterface):
 
         while timeout < 0 or time() < deadline:
             if callback is not None and callback():
-                return
+                return None
             try:
                 waiting = self.port.in_waiting
                 if waiting:
@@ -2376,8 +2377,12 @@ class SerialCommandInterface(CommandInterface):
                 timestamp of the status update, the status code, and the
                 corresponding status message (if any).
         """
-        self.ping(timeout=timeout, callback=callback)
-        return super().getStatus()
+        with self.device._busy:
+            lastStatus = self.status[0]
+            self.ping(timeout=timeout, callback=callback)
+            if self.status[0] == lastStatus:
+                raise CommandError('Device responded but did not report its status')
+            return self.status
 
 
     def _updateAll(self,
@@ -2889,13 +2894,13 @@ class FileCommandInterface(CommandInterface):
                     if not response:
                         logger.debug('Ignoring timeout waiting for CMDQueue '
                                      'to empty because no response required')
-                        return
+                        return None
 
                     raise DeviceTimeout("Timed out waiting for device to complete "
                                         "queued commands (%s remaining)" % queueDepth)
 
                 if callback is not None and callback():
-                    return
+                    return None
 
             self._writeCommand(ebml)
 
@@ -2906,14 +2911,14 @@ class FileCommandInterface(CommandInterface):
                     return data
 
                 if callback is not None and callback():
-                    return
+                    return None
 
                 sleep(interval)
 
             if not response:
                 logger.debug('Ignoring timeout waiting for response '
                              'because no response required')
-                return
+                return None
 
             raise DeviceTimeout("Timed out waiting for command response (%s seconds)" % timeout)
 

--- a/endaq/device/command_interfaces.py
+++ b/endaq/device/command_interfaces.py
@@ -12,6 +12,7 @@ import shutil
 import string
 import struct
 import sys
+from threading import Event
 from time import sleep, time, struct_time
 from typing import Any, AnyStr, Dict, Generator, List, Optional, Tuple, Union, Callable
 from uuid import uuid4
@@ -100,6 +101,7 @@ class CommandInterface:
         # message. Not available on all interfaces.
         self.response: Tuple[float, Optional[int], Optional[str]] = (0, None, None)
         self.status: Tuple[float, Optional[int], Optional[str]] = (0, None, None)
+        self._statusChanged = Event()
 
         # The time and value of the device's last reported LockID.
         self.lockId: Tuple[Optional[float], Optional[bytes]] = (0, None)
@@ -475,6 +477,7 @@ class CommandInterface:
             except ValueError:
                 logger.debug('Received unknown DeviceStatusCode: {}'.format(statusCode))
             self.status = now, statusCode, statusMsg
+            self._statusChanged.set()
 
         lockId = lockId or '\x00' * 16
         if lockId != self.lockId[1]:
@@ -2379,11 +2382,11 @@ class SerialCommandInterface(CommandInterface):
                 corresponding status message (if any).
         """
         with self.device._busy:
-            lastStatus = self.status[0]
             self.ping(timeout=timeout, callback=callback)
-            if self.status[0] == lastStatus:
-                raise CommandError('Device responded but did not report its status')
-            return self.status
+            if self._statusChanged.is_set():
+                self._statusChanged.clear()
+                return self.status
+            raise CommandError('Device responded but did not report its status')
 
 
     def _updateAll(self,

--- a/endaq/device/command_interfaces.py
+++ b/endaq/device/command_interfaces.py
@@ -259,10 +259,11 @@ class CommandInterface:
         if not response:
             return None
 
-        for name, code in [(k, v) for k, v in response.items()
-                           if k in vars(response_codes)]:
+        codes = vars(response_codes)
+        for name, code in ((k, v) for k, v in response.items()
+                           if k in codes):
             try:
-                response[name] = vars(response_codes)[name](code)
+                response[name] = codes[name](code)
             except (AttributeError, TypeError, ValueError):
                 logger.debug('Received unknown {}: {}'.format(name, code))
                 pass
@@ -2183,7 +2184,7 @@ class SerialCommandInterface(CommandInterface):
         """ Verify the recorder is present and responding. Not supported on
             all devices.
 
-            :param data: An optional binary payload, not larger than 30 bytes, 
+            :param data: An optional binary payload, not larger than 30 bytes,
                 returned by the recorder verbatim.
             :param timeout: Time (in seconds) to wait for a response before
                 raising a :class:`~.endaq.device.DeviceTimeout` exception.
@@ -2199,7 +2200,7 @@ class SerialCommandInterface(CommandInterface):
         if data is not None:
             if len(data) > 30:
                 raise ValueError("Payload larger than 30 bytes.")
-            
+
         cmd = {'EBMLCommand': {'SendPing': b'' if data is None else data}}
         response = self._sendCommand(cmd, timeout=timeout, interval=interval,
                                      callback=callback)
@@ -2501,7 +2502,7 @@ class SerialCommandInterface(CommandInterface):
                 return None
 
             lockId = response.get('LockID', None)
-            
+
             if isinstance(lockId, (bytearray, bytes)) and not any(lockId):
                 # All zeros; lock not set.
                 return None

--- a/endaq/device/command_interfaces.py
+++ b/endaq/device/command_interfaces.py
@@ -642,6 +642,25 @@ class CommandInterface:
         raise NotImplementedError
 
 
+    def getStatus(self,
+                  timeout: Union[int, float] = 10,
+                  callback: Optional[Callable] = None
+                  ) -> Tuple[float, Optional[int], Optional[str]]:
+        """ Get the device's status.
+
+            :param timeout: Time (in seconds) to wait for the recorder to
+                respond. 0 will return immediately.
+            :param callback: A function to call each response-checking
+                cycle. If the callback returns `True`, the wait for a response
+                will be cancelled. The callback function should require no
+                arguments.
+            :return: The device's current status, as a tuple containing the
+                timestamp of the status update, the status code, and the
+                corresponding status message (if any).
+        """
+        return self.status
+
+
     def getBatteryStatus(self,
                          timeout: Union[int, float] = 1,
                          callback: Optional[Callable] = None) -> bool:
@@ -2336,6 +2355,26 @@ class SerialCommandInterface(CommandInterface):
                                       wait=wait,
                                       timeout=timeout,
                                       callback=callback)
+
+
+    def getStatus(self,
+                  timeout: Union[int, float] = 10,
+                  callback: Optional[Callable] = None
+                  ) -> Tuple[float, Optional[int], Optional[str]]:
+        """ Get the device's status.
+
+            :param timeout: Time (in seconds) to wait for the recorder to
+                respond. 0 will return immediately.
+            :param callback: A function to call each response-checking
+                cycle. If the callback returns `True`, the wait for a response
+                will be cancelled. The callback function should require no
+                arguments.
+            :return: The device's current status, as a tuple containing the
+                timestamp of the status update, the status code, and the
+                corresponding status message (if any).
+        """
+        self.ping(timeout=timeout, callback=callback)
+        return super().getStatus()
 
 
     def _updateAll(self,

--- a/endaq/device/util.py
+++ b/endaq/device/util.py
@@ -3,7 +3,7 @@ Some basic utility functions, for internal use.
 """
 
 import calendar
-from datetime import datetime
+import datetime
 import errno
 import os.path
 import pathlib
@@ -82,14 +82,25 @@ def dump(data: ByteString, length: int = 8) -> str:
     return ' '.join(f'{x:02x}' for x in data[:length])
 
 
-def time2epoch(t: Union[int, float, datetime, tuple]) -> int:
+def time2epoch(t: Union[int, float, datetime.datetime, tuple]) -> int:
     """ Convenient function to convert any of several representations
         of time (`datetime`, timestamps, time struct, etc.) into
-        integer UNIX epoch timestamps.
+        integer UNIX epoch timestamps (UTC).
     """
-    if isinstance(t, datetime):
+    if isinstance(t, datetime.datetime):
         return calendar.timegm(t.timetuple())
     elif isinstance(t, tuple):
         return calendar.timegm(t)
     else:
         return int(t)
+
+
+def utcfromtimestamp(timestamp: int) -> datetime.datetime:
+    """ Convert an Epoch timestamp to a UTC datetime, getting around
+        deprecated `datetime.datetime.utcfromtimestamp` needed for
+        Python 3.9. To be removed once Python 3.9 is sunsetted.
+    """
+    try:
+        return datetime.datetime.fromtimestamp(timestamp, datetime.UTC)
+    except AttributeError:
+        return datetime.datetime.utcfromtimestamp(timestamp)

--- a/tests/mock_hardware.py
+++ b/tests/mock_hardware.py
@@ -6,6 +6,7 @@ TODO: BUG: There is an issue reading responses when using MockCommandFileIO,
     but it only seems to happen when running tests on GitHub. The test
     `test_command_scanWifi()` has been modified to exclude the serial W8.
 """
+from copy import deepcopy
 
 import endaq.device
 from endaq.device.command_interfaces import CommandInterface, FileCommandInterface
@@ -88,7 +89,7 @@ class MockCommandFileIO:
         a `FileCommandInterface`):
 
             mock_io = MockCommandFileIO(dev)
-            mock_io.response = mock_io.encodeResponse(<EBMLResponse dict>)
+            mock_io.setResponse(<EBMLResponse dict>)
     """
 
     def __init__(self, device: endaq.device.Recorder):
@@ -120,14 +121,19 @@ class MockCommandFileIO:
         return self.response
 
 
-    def encodeResponse(self, response: dict) -> bytearray:
-        """ Utility method to encode a dictionary containing a device
-            response into the raw format expected of the device.
+    def setResponse(self, response: dict, increment: bool = True):
+        """ Encode a dictionary containing a device response into the raw
+            format expected of the device and set it as the simulated response
+            to the next command (`MockCommandFileIO.response`.
 
             :param response: The response dictionary.
-            :return: The response as raw binary.
+            :param increment: If `True`, set the `ResponseIdx` in the response
+                to the device's. If `False`, the response is encoded verbatim.
         """
-        return CommandInterface._encode(self.device.command, response, checkSize=False)
+        if increment:
+            response = deepcopy(response)
+            response['EBMLResponse']['ResponseIdx'] = self.device.command.index + 1
+        self.response = CommandInterface._encode(self.device.command, response, checkSize=False)
 
 
 
@@ -146,13 +152,13 @@ class MockCommandSerialIO:
         a `SerialCommandInterface`):
 
             mock_io = MockCommandSerialIO(dev)
-            mock_io.response = mock_io.encodeResponse({'EBMLResponse':
-                                                       {'ResponseIdx': dev.command.index + 1,
-                                                        'CMDQueueDepth': 1,
-                                                        'CommandResponseCode': 0,
-                                                        'DeviceStatusCode': 0,
-                                                        'PingReply': bytearray(b'hello')}},
-                                                      resultcode=0)
+            mock_io.setResponse({'EBMLResponse':
+                                   {'ResponseIdx': 2,
+                                    'CMDQueueDepth': 1,
+                                    'CommandResponseCode': 0,
+                                    'DeviceStatusCode': 0,
+                                    'PingReply': bytearray(b'hello')}},
+                                  resultcode=0)
             assert dev.command.ping() == bytearray(b'hello')
 
     """
@@ -178,17 +184,26 @@ class MockCommandSerialIO:
         self.port.response = data
 
 
-    def encodeResponse(self, response: dict, resultcode: int = 0) -> bytearray:
-        """ Utility method to encode a dictionary containing a device
-            response into the raw format expected from the device.
+    def setResponse(self,
+                    response: dict,
+                    resultcode: int = 0,
+                    increment: bool = True) -> bytearray:
+        """ Encode a dictionary containing a device response into the raw
+            format expected of the device and set it as the simulated response
+            to the next command (`MockCommandSerialIO.response`.
 
             :param response: The response dictionary.
             :param resultcode: The Corbus response code. Not applicable to
                 `FileCommandInterface`. Non-zero is an error.
+            :param increment: If `True`, set the `ResponseIdx` in the response
+                to the device's. If `False`, the response is encoded verbatim.
             :return: The response as raw binary.
         """
+        if increment:
+            response = deepcopy(response)
+            response['EBMLResponse']['ResponseIdx'] = self.device.command.index + 1
         response = CommandInterface._encode(self.device.command, response, checkSize=False)
-        return hdlc_encode(bytearray([0x81, 0x00, resultcode]) + response)
+        self.response = hdlc_encode(bytearray([0x81, 0x00, resultcode]) + response)
 
 
     def getSerialPort(self, *args, **kwargs):

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -119,6 +119,7 @@ def test_command_getStatus(dev):
     mock_io = applyMockCommandIO(dev)
     mock_io.setResponse(TEST_RESPONSE, resultcode=0)
 
+    dev.command.status = 0, None, None
     oldstatus = dev.command.status
     newstatus = dev.command.getStatus()
     assert oldstatus != newstatus

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -2,7 +2,6 @@
 Tests of the command interfaces.
 """
 
-from copy import deepcopy
 import os.path
 import pytest
 
@@ -11,7 +10,7 @@ from endaq.device import getRecorder, UnsupportedFeature
 from endaq.device.command_interfaces import CommandInterface, FileCommandInterface, SerialCommandInterface
 
 from .fake_recorders import RECORDER_PATHS
-from .mock_hardware import applyMockCommandIO, MockCommandSerialIO
+from .mock_hardware import applyMockCommandIO
 
 # Clear any cached devices, just to be safe
 endaq.device.RECORDERS.clear()
@@ -33,6 +32,7 @@ TEST_COMMAND = {
         'CommandIdx': 2}}
 
 # Simple example response to simple example command
+# Note: the mock IO method `setResponse()` will increment `DeviceStatusCode`
 TEST_RESPONSE = {
     'EBMLResponse': {
         'ResponseIdx': 2,
@@ -109,14 +109,19 @@ def test_command_ping(dev):
     """ Test the `ping()` command on devices that support it.
     """
     mock_io = applyMockCommandIO(dev)
-    mock_io.response = mock_io.encodeResponse({'EBMLResponse':
-                                               {'ResponseIdx': dev.command.index + 1,
-                                                'CMDQueueDepth': 1,
-                                                'DeviceStatusCode': 0,
-                                                'PingReply': bytearray(b'hello')}},
-                                              resultcode=0)
-    
-    assert dev.command.ping() == bytearray(b'hello')
+    mock_io.setResponse(TEST_RESPONSE, resultcode=0)
+
+    assert dev.command.ping() == TEST_RESPONSE['EBMLResponse']['PingReply']
+
+
+@pytest.mark.parametrize("dev", SERIAL_DEVICES)
+def test_command_getStatus(dev):
+    mock_io = applyMockCommandIO(dev)
+    mock_io.setResponse(TEST_RESPONSE, resultcode=0)
+
+    oldstatus = dev.command.status
+    newstatus = dev.command.getStatus()
+    assert oldstatus != newstatus
 
 
 @pytest.mark.parametrize("dev", WIFI_DEVICES)
@@ -124,7 +129,5 @@ def test_command_scanWifi(dev):
     """ Test the `scanWifi()` command on devices that support it.
     """
     mock_io = applyMockCommandIO(dev)
-    response = deepcopy(WIFI_SCAN)
-    response['EBMLResponse']['ResponseIdx'] = dev.command.index + 1
-    mock_io.response = mock_io.encodeResponse(response, resultcode=0)
-    assert dev.command.scanWifi() == response['EBMLResponse']['WiFiScanResult']['AP']
+    mock_io.setResponse(WIFI_SCAN, resultcode=0)
+    assert dev.command.scanWifi() == WIFI_SCAN['EBMLResponse']['WiFiScanResult']['AP']


### PR DESCRIPTION
* Implemented `getStatus()` for `CommandInterface` and `SerialCommandInterface`
* Added workaround for deprecated `datetime.utcfromtimestamp`
* Added explicit returns/return types in various places to make the linter happy
* Additional little bits of cleanup