### PR TITLE
Add stop recording ability without need for connection.

### DIFF
--- a/endaq/device/__init__.py
+++ b/endaq/device/__init__.py
@@ -347,6 +347,25 @@ def fromRecording(doc: Dataset) -> Recorder:
     return recType.fromRecording(doc)
 
 
+def stopAllRecording(strict: bool = True):
+    """ Stop all recorders connected via serial.
+
+        :param strict: If `False`, only the directory structure is used
+            to identify a recorder. If `True`, non-FAT file systems will
+            be automatically rejected.
+    """
+    fake = NonRecorder()
+    fake.command = SerialCommandInterface(fake)
+
+    for port, sn in SerialCommandInterface._possibleRecorders(strict=strict):
+        fake.command.port = None
+        fake._snInt, fake._sn = sn, str(sn)
+
+        with _module_busy:
+            logger.info(f'Getting info for SN {sn} via serial')
+            fake.command.stopRecording()
+
+
 # ============================================================================
 # 
 # ============================================================================

--- a/endaq/device/__init__.py
+++ b/endaq/device/__init__.py
@@ -362,8 +362,15 @@ def stopAllRecording(strict: bool = True):
         fake._snInt, fake._sn = sn, str(sn)
 
         with _module_busy:
-            logger.info(f'Getting info for SN {sn} via serial')
-            fake.command.stopRecording()
+            try:
+                logger.debug(f'Getting info for SN {sn} via serial')
+                fake.command.stopRecording()
+            except CommandError as err:
+                if err.errno != DeviceStatusCode.ERR_INVALID_COMMAND:
+                    logger.debug(f'Unexpected {type(err).__name__} getting info for {sn}: {err}')
+                continue
+            except:
+                continue
 
 
 # ============================================================================

--- a/endaq/device/linux.py
+++ b/endaq/device/linux.py
@@ -158,17 +158,17 @@ def getDeviceList(types: dict, strict: bool = True) -> list:
 
     result = set()
 
-    for device, mountpoint, fstype, opts, maxfile, maxpath in psutil.disk_partitions():
+    for device in psutil.disk_partitions():
         try:
-            if not os.path.exists(device):
+            if not os.path.exists(device.mountpoint):
                 continue
             for t in types:
-                if t.isRecorder(mountpoint, strict=strict):
-                    result.add(mountpoint)
+                if t.isRecorder(device.mountpoint, strict=strict):
+                    result.add(device.mountpoint)
         except IOError as err:
             # Rare error, may be caused by flaky device or USB.
             msg = ("getDeviceList(): Could not access {} ({}); "
-                   "ignoring error and continuing".format(device, err))
+                   "ignoring error and continuing".format(device[0], err))
             warnings.warn(msg)
             logger.error(msg)
 


### PR DESCRIPTION
When an endaq is running, you can't connect to it to tell it to stop recording programmatically. I have added a quick feature to allow this.

Along with this, I fixed a bug with Endaqs where they crashed on searching for an Endaq on Python 3.11 Linux.