### PR TITLE
Fixed `index` argument check in `SerialCommandInterface._sendCommand()`

### DIFF
--- a/endaq/device/command_interfaces.py
+++ b/endaq/device/command_interfaces.py
@@ -2166,7 +2166,7 @@ class SerialCommandInterface(CommandInterface):
                             logger.debug('Command queue full, retrying.')
                         else:
                             respIdx = resp.get('ResponseIdx', self.index)
-                            if respIdx == self.index:
+                            if not index or respIdx == self.index:
                                 return resp if response else None
                             else:
                                 logger.debug('Bad ResponseIdx; expected {}, got {}. '


### PR DESCRIPTION
In `SerialCommandInterface._sendCommand()`, the `index` argument wasn't being used when checking the response's `ResponseIdx`. Among other things, this caused the first call of `getDevices()` to fail if a device was already recording.