### PR TITLE
Abstracted device info caching

### DIFF
--- a/endaq/device/mqtt/caching.py
+++ b/endaq/device/mqtt/caching.py
@@ -1,16 +1,18 @@
 """
-Mechanisms for saving device information (e.g., IDE headers or data
-retrieved from the device.
+Mechanisms for the Device Manager to load and save cached device information
+(e.g., IDE headers or data retrieved from the device).
+
+By default, the caching is done via files in a working directory. The
+mechanism is abstracted to make it easy to swap out for another type
+of storage (e.g., a database).
 """
 
+import threading
 from abc import ABC, abstractmethod
 from collections import defaultdict
 import logging
 import os
 import sys
-from typing import Optional
-
-from ..client import synchronized
 
 # Paths for cached data (IDE headers, etc.)
 if sys.platform == 'win32':
@@ -31,39 +33,19 @@ class BaseCache(ABC):
     (info, IDE header, etc.).
     """
 
-    def __init__(self):
-        """
-        Base class that abstracts the mechanism behind caching device data
-        (info, IDE header, etc.).
-        """
-        self._cache = defaultdict(dict)
-        self._modified = defaultdict(dict)
-
-
-    @synchronized
-    def _get(self, sn: int, base: str) -> Optional[bytes]:
-        return self._cache[sn].get(base)
-
-
-    @synchronized
-    def _set(self, sn: int, base: str, data: bytes):
-        self._cache[sn][base] = data
-
-
-    def get(self, sn: int, base: str) -> Optional[bytes]:
+    @abstractmethod
+    def get(self, sn: int, base: str) -> bytes:
         """
         Get the latest cached version device data.
 
         :param sn: The enDAQ device's serial number.
         :param base: The name of the info, e.g. ``"header"`` or ``"info0"``
-        :return: The cached data, or `None` if no cache exists.
+        :return: The cached data, or an empty bytestring if no cache exists.
         """
-        data = self._get(sn, base)
-        if data:
-            return data
-        return self.revert(sn, base)
+        raise NotImplementedError()
 
 
+    @abstractmethod
     def set(self, sn: int, base: str, data: bytes) -> bool:
         """
         Set the data cache in memory.
@@ -73,75 +55,30 @@ class BaseCache(ABC):
         :param data: The new header.
         :return: True if the cache was updated with new data.
         """
-        old = self._get(sn, base)
-        if old == data:
-            return False
-        self._set(sn, base, data)
-        self.setModified(sn, base, True)
-        return True
+        raise NotImplementedError()
 
-
-    @synchronized
-    def modified(self, sn: int, base: str) -> bool:
-        """
-        Check if the cached data was modified since last save.
-
-        :param sn: The enDAQ device's serial number.
-        :param base: The name of the info, e.g. ``"header"`` or ``"info0"``
-        """
-        return self._modified[sn].get(base, False)
-
-
-    @synchronized
-    def setModified(self, sn: int, base: str, modified=True):
-        """
-        Explicitly set (or clear) the flag indicating a change in a set of
-        cached data since last save.
-
-        :param sn: The enDAQ device's serial number.
-        :param base: The name of the info, e.g. ``"header"`` or ``"info0"``
-        :param modified: The new value.
-        """
-        self._modified[sn][base] = modified
-
-
-    # =======================================================================
-    #
-    # =======================================================================
 
     @abstractmethod
-    def save(self, sn: int, base: str, force=False) -> bool:
+    def clear(self, sn: int, base: str) -> bool:
         """
-        Write the currently cached data.
+        Remove data from the cache.
 
         :param sn: The enDAQ device's serial number.
         :param base: The name of the info, e.g. ``"header"`` or ``"info0"``
-        :param force: If `True`, overwrite the cached header even if it
-            has not been changed, updating its cache timestamp.
+        :return: `True` if the cached existed and its removal was successful.
         """
         raise NotImplementedError()
 
 
     @abstractmethod
-    def revert(self, sn: int, base: str) -> Optional[bytes]:
-        """
-        Reload the last saved version of the cached data.
-
-        :param sn: The enDAQ device's serial number.
-        :param base: The name of the info, e.g. ``"header"`` or ``"info0"``
-        :return: The cached data, or `None` if no cache exists.
-        """
-        raise NotImplementedError()
-
-
-    @abstractmethod
-    def getTimestamp(self, sn: int, base: str) -> Optional[float]:
+    def getTimestamp(self, sn: int, base: str) -> float:
         """
         Get the date/time the cached data was last saved.
 
         :param sn: The enDAQ device's serial number.
         :param base: The name of the info, e.g. ``"header"`` or ``"info0"``
-        :return: The update's timestamp (UNIX epoch).
+        :return: The update's timestamp (UNIX epoch), or zero if there is no
+            cached data.
         """
         raise NotImplementedError()
 
@@ -165,6 +102,7 @@ class FileCache(BaseCache):
             default varies by platforn.
         """
         self._cachePath = path
+        self._locks = defaultdict(threading.RLock)
         super().__init__()
 
 
@@ -176,64 +114,64 @@ class FileCache(BaseCache):
         :param base: The name of the info, e.g. ``"header"`` or ``"info0"``
         :return: The full file path and name
         """
-        return os.path.realpath(os.path.join(self._cachePath, f'{sn:08d}', base))
-
-
-    @synchronized
-    def save(self, sn: int, base: str, force=False):
-        """
-        Write the currently cached data.
-
-        :param sn: The enDAQ device's serial number.
-        :param base: The name of the info, e.g. ``"header"`` or ``"info0"``
-        :param force: If `True`, overwrite the cached header even if it
-            has not been changed, updating its cache timestamp.
-        """
-        if not (force or self.modified(sn, base)):
-            return
-
-        data = self._get(sn, base)
-        filename = self._makeFilename(sn, base)
-        dirname = os.path.dirname(filename)
-
         try:
-            os.makedirs(dirname, exist_ok=True)
-        except IOError as err:
-            logger.error(f'Error creating cache directory {dirname}: {err!r}')
-            return
-
-        try:
-            with open(filename, 'wb') as f:
-                f.write(data)
-            self.setModified(base, sn, False)
-
-        except IOError as err:
-            logger.error(f'Error saving cache data {sn:08d}/{base}: {err!r}')
+            sn = f'{sn:08d}'
+        except (TypeError, ValueError):
+            sn = str(sn)
+        return os.path.realpath(os.path.join(self._cachePath, sn, str(base)))
 
 
-    @synchronized
-    def revert(self, sn: int, base: str) -> Optional[bytes]:
+    def get(self, sn: int, base: str) -> bytes:
         """
-        Reload the last saved version of the cached data.
+        Retrieve cached data.
 
         :param sn: The enDAQ device's serial number.
         :param base: The name of the info, e.g. ``"header"`` or ``"info0"``
         :return: The cached data, or `None` if no cache exists.
         """
-        old = self._get(sn, base)
         filename = self._makeFilename(sn, base)
-        
-        try:
-            with open(filename, 'rb') as f:
-                data = f.read()
-            self._set(sn, base, data)
-            self.setModified(base, sn, old and old != data)
-            return data
-        except FileNotFoundError:
-            return None
-        except IOError as err:
-            logger.error(f'Error loading file {filename}', exc_info=err)
-        
+
+        with self._locks[filename]:
+            try:
+                with open(filename, 'rb') as f:
+                    data = f.read()
+                return data
+            except FileNotFoundError:
+                pass
+            except IOError as err:
+                logger.error(f'Error loading file {filename}', exc_info=err)
+
+            return b''
+
+
+    def set(self, sn: int, base: str, data: bytes) -> bool:
+        """
+        Write data to the cache.
+
+        :param sn: The enDAQ device's serial number.
+        :param base: The name of the info, e.g. ``"header"`` or ``"info0"``
+        :param data: The new header.
+        :return: `True` if the cache was updated with new data.
+        """
+        filename = self._makeFilename(sn, base)
+
+        with self._locks[filename]:
+            dirname = os.path.dirname(filename)
+            try:
+                os.makedirs(dirname, exist_ok=True)
+            except IOError as err:
+                logger.error(f'Error creating cache directory {dirname}: {err!r}')
+                return False
+
+            try:
+                with open(filename, 'wb') as f:
+                    f.write(data)
+                return True
+
+            except IOError as err:
+                logger.error(f'Error saving cache data {filename}: {err!r}')
+                return False
+
 
     def getTimestamp(self, sn: int, base: str) -> float:
         """
@@ -241,14 +179,38 @@ class FileCache(BaseCache):
 
         :param sn: The enDAQ device's serial number.
         :param base: The name of the info, e.g. ``"header"`` or ``"info0"``
-        :return: The update's timestamp (UNIX epoch).
+        :return: The update's timestamp (UNIX epoch), or zero if there is no
+            cached data.
         """
         filename = self._makeFilename(sn, base)
-        try:
-            return os.path.getmtime(filename)
-        except FileNotFoundError:
-            pass
-        except IOError as err:
-            logger.error(f'Error getting timestamp of {filename}: {err!r}')
-            
-        return 0
+
+        with self._locks[filename]:
+            try:
+                return os.path.getmtime(filename)
+            except FileNotFoundError:
+                pass
+            except IOError as err:
+                logger.error(f'Error getting timestamp of {filename}: {err!r}')
+
+            return 0
+
+
+    def clear(self, sn: int, base: str) -> bool:
+        """
+        Remove data from the cache.
+
+        :param sn: The enDAQ device's serial number.
+        :param base: The name of the info, e.g. ``"header"`` or ``"info0"``
+        :return: `True` if the cached existed and its removal was successful.
+        """
+        filename = self._makeFilename(sn, base)
+
+        with self._locks[filename]:
+            try:
+                os.remove(filename)
+                return True
+            except FileNotFoundError:
+                return False
+            except IOError as err:
+                logger.error(f'Error removing cached file {filename}: {err!r}')
+                return False

--- a/endaq/device/mqtt/caching.py
+++ b/endaq/device/mqtt/caching.py
@@ -146,6 +146,15 @@ class FileCache(BaseCache):
         return os.path.realpath(os.path.join(self._cachePath, sn, f'{base}.cache'))
 
 
+    @synchronized
+    def _getLock(self, filename: str) -> threading.RLock:
+        """ Get a lock object corresponding to a filename.
+        """
+        # defaultdict has a non-zero chance of race condition when
+        # instantiating the default object.
+        return self._locks[filename]
+        
+
     def get(self, sn: int, base: str) -> bytes:
         """
         Retrieve cached data.
@@ -156,7 +165,7 @@ class FileCache(BaseCache):
         """
         filename = self._makeFilename(sn, base)
 
-        with self._locks[filename]:
+        with self._getLock(filename):
             try:
                 with open(filename, 'rb') as f:
                     data = f.read()
@@ -180,7 +189,7 @@ class FileCache(BaseCache):
         """
         filename = self._makeFilename(sn, base)
 
-        with self._locks[filename]:
+        with self._getLock(filename):
             dirname = os.path.dirname(filename)
             try:
                 os.makedirs(dirname, exist_ok=True)
@@ -209,7 +218,7 @@ class FileCache(BaseCache):
         """
         filename = self._makeFilename(sn, base)
 
-        with self._locks[filename]:
+        with self._getLock(filename):
             try:
                 return os.path.getmtime(filename)
             except FileNotFoundError:
@@ -230,7 +239,7 @@ class FileCache(BaseCache):
         """
         filename = self._makeFilename(sn, base)
 
-        with self._locks[filename]:
+        with self._getLock(filename):
             try:
                 os.remove(filename)
                 return True

--- a/endaq/device/mqtt/caching.py
+++ b/endaq/device/mqtt/caching.py
@@ -10,9 +10,14 @@ of storage (e.g., a database).
 import threading
 from abc import ABC, abstractmethod
 from collections import defaultdict
+from glob import glob
 import logging
 import os
 import sys
+from time import time
+from typing import List, Optional, Tuple
+
+from ..client import synchronized
 
 # Paths for cached data (IDE headers, etc.)
 if sys.platform == 'win32':
@@ -48,7 +53,7 @@ class BaseCache(ABC):
     @abstractmethod
     def set(self, sn: int, base: str, data: bytes) -> bool:
         """
-        Set the data cache in memory.
+        Store device data in the cache.
 
         :param sn: The enDAQ device's serial number.
         :param base: The name of the info, e.g. ``"header"`` or ``"info0"``
@@ -79,6 +84,26 @@ class BaseCache(ABC):
         :param base: The name of the info, e.g. ``"header"`` or ``"info0"``
         :return: The update's timestamp (UNIX epoch), or zero if there is no
             cached data.
+        """
+        raise NotImplementedError()
+
+
+    @abstractmethod
+    def cleanCache(self,
+                   sn: Optional[int] = None,
+                   base: Optional[str] = None,
+                   retention: float = 24) -> List[Tuple[int, str, Optional[Exception]]]:
+        """
+        Clear out old cached data.
+
+        :param sn: The enDAQ device's serial number, or `None` for all
+            devices.
+        :param base: The name of the info, e.g. ``"header"`` or ``"info0"``,
+            or `None` for all cached info.
+        :param retention: The cached file retention period. Files not
+            modified in `retention` hours will be removed.
+        :return: A list of tuples: serial number, base, and failure. Failure
+            will be `None` if successful, an exception if not.
         """
         raise NotImplementedError()
 
@@ -118,7 +143,7 @@ class FileCache(BaseCache):
             sn = f'{sn:08d}'
         except (TypeError, ValueError):
             sn = str(sn)
-        return os.path.realpath(os.path.join(self._cachePath, sn, str(base)))
+        return os.path.realpath(os.path.join(self._cachePath, sn, f'{base}.cache'))
 
 
     def get(self, sn: int, base: str) -> bytes:
@@ -214,3 +239,46 @@ class FileCache(BaseCache):
             except IOError as err:
                 logger.error(f'Error removing cached file {filename}: {err!r}')
                 return False
+
+
+    @synchronized
+    def cleanCache(self,
+                   sn: Optional[int] = None,
+                   base: Optional[str] = None,
+                   retention: float = 24) -> List[Tuple[int, str, Optional[Exception]]]:
+        """
+        Clear out old cached data.
+
+        :param sn: The enDAQ device's serial number, or `None` for all
+            devices.
+        :param base: The name of the info, e.g. ``"header"`` or ``"info0"``,
+            or `None` for all cached info.
+        :param retention: The cached file retention period. Files not
+            modified in `retention` hours will be removed.
+        :return: A list of tuples: serial number, base, and failure. Failure
+            will be `None` if successful, an exception if not.
+        """
+        limit = retention * 60 * 60
+        cleared = []
+
+        sn = sn or '*'
+        base = base or '*'
+
+        for filename in glob(self._makeFilename(sn, base)):
+            dirname, b = os.path.split(filename)
+            s = os.path.basename(dirname)
+            b = os.path.splitext(b)[0]
+
+            try:
+                s = int(s)
+            except (TypeError, ValueError):
+                pass
+
+            try:
+                if time() - os.path.getmtime(filename) > limit:
+                    os.remove(filename)
+                    cleared.append((s, b, None))
+            except (IOError, OSError) as err:
+                cleared.append((s, b, err))
+
+        return cleared

--- a/endaq/device/mqtt/caching.py
+++ b/endaq/device/mqtt/caching.py
@@ -1,0 +1,254 @@
+"""
+Mechanisms for saving device information (e.g., IDE headers or data
+retrieved from the device.
+"""
+
+from abc import ABC, abstractmethod
+from collections import defaultdict
+import logging
+import os
+import sys
+from typing import Optional
+
+from ..client import synchronized
+
+# Paths for cached data (IDE headers, etc.)
+if sys.platform == 'win32':
+    CACHE_PATH = os.path.expandvars(r'%APPDATA%\endaq\mqtt_manager')
+else:
+    CACHE_PATH = os.path.expanduser('~/.endaq/mqtt_manager')
+
+logger = logging.getLogger(__name__)
+
+
+# ===========================================================================
+#
+# ===========================================================================
+
+class BaseCache(ABC):
+    """
+    Base class that abstracts the mechanism behind caching device data
+    (info, IDE header, etc.).
+    """
+
+    def __init__(self):
+        """
+        Base class that abstracts the mechanism behind caching device data
+        (info, IDE header, etc.).
+        """
+        self._cache = defaultdict(dict)
+        self._modified = defaultdict(dict)
+
+
+    @synchronized
+    def _get(self, sn: int, base: str) -> Optional[bytes]:
+        return self._cache[sn].get(base)
+
+
+    @synchronized
+    def _set(self, sn: int, base: str, data: bytes):
+        self._cache[sn][base] = data
+
+
+    def get(self, sn: int, base: str) -> Optional[bytes]:
+        """
+        Get the latest cached version device data.
+
+        :param sn: The enDAQ device's serial number.
+        :param base: The name of the info, e.g. ``"header"`` or ``"info0"``
+        :return: The cached data, or `None` if no cache exists.
+        """
+        data = self._get(sn, base)
+        if data:
+            return data
+        return self.revert(sn, base)
+
+
+    def set(self, sn: int, base: str, data: bytes) -> bool:
+        """
+        Set the data cache in memory.
+
+        :param sn: The enDAQ device's serial number.
+        :param base: The name of the info, e.g. ``"header"`` or ``"info0"``
+        :param data: The new header.
+        :return: True if the cache was updated with new data.
+        """
+        old = self._get(sn, base)
+        if old == data:
+            return False
+        self._set(sn, base, data)
+        self.setModified(sn, base, True)
+        return True
+
+
+    @synchronized
+    def modified(self, sn: int, base: str) -> bool:
+        """
+        Check if the cached data was modified since last save.
+
+        :param sn: The enDAQ device's serial number.
+        :param base: The name of the info, e.g. ``"header"`` or ``"info0"``
+        """
+        return self._modified[sn].get(base, False)
+
+
+    @synchronized
+    def setModified(self, sn: int, base: str, modified=True):
+        """
+        Explicitly set (or clear) the flag indicating a change in a set of
+        cached data since last save.
+
+        :param sn: The enDAQ device's serial number.
+        :param base: The name of the info, e.g. ``"header"`` or ``"info0"``
+        :param modified: The new value.
+        """
+        self._modified[sn][base] = modified
+
+
+    # =======================================================================
+    #
+    # =======================================================================
+
+    @abstractmethod
+    def save(self, sn: int, base: str, force=False) -> bool:
+        """
+        Write the currently cached data.
+
+        :param sn: The enDAQ device's serial number.
+        :param base: The name of the info, e.g. ``"header"`` or ``"info0"``
+        :param force: If `True`, overwrite the cached header even if it
+            has not been changed, updating its cache timestamp.
+        """
+        raise NotImplementedError()
+
+
+    @abstractmethod
+    def revert(self, sn: int, base: str) -> Optional[bytes]:
+        """
+        Reload the last saved version of the cached data.
+
+        :param sn: The enDAQ device's serial number.
+        :param base: The name of the info, e.g. ``"header"`` or ``"info0"``
+        :return: The cached data, or `None` if no cache exists.
+        """
+        raise NotImplementedError()
+
+
+    @abstractmethod
+    def getTimestamp(self, sn: int, base: str) -> Optional[float]:
+        """
+        Get the date/time the cached data was last saved.
+
+        :param sn: The enDAQ device's serial number.
+        :param base: The name of the info, e.g. ``"header"`` or ``"info0"``
+        :return: The update's timestamp (UNIX epoch).
+        """
+        raise NotImplementedError()
+
+
+# ===========================================================================
+#
+# ===========================================================================
+
+class FileCache(BaseCache):
+    """
+    Class that implements a file-based mechanism for reading/writing cached
+    device data (info, IDE header, etc.).
+    """
+
+    def __init__(self, path: str = CACHE_PATH):
+        """
+        Class that implements a file-based mechanism for reading/writing
+        cached device data (info, IDE header, etc.).
+
+        :param path: The root directory of the cached data. Note that the
+            default varies by platforn.
+        """
+        self._cachePath = path
+        super().__init__()
+
+
+    def _makeFilename(self, sn: int, base: str) -> str:
+        """
+        Generate a cache filename.
+
+        :param sn: The enDAQ device's serial number.
+        :param base: The name of the info, e.g. ``"header"`` or ``"info0"``
+        :return: The full file path and name
+        """
+        return os.path.realpath(os.path.join(self._cachePath, f'{sn:08d}', base))
+
+
+    @synchronized
+    def save(self, sn: int, base: str, force=False):
+        """
+        Write the currently cached data.
+
+        :param sn: The enDAQ device's serial number.
+        :param base: The name of the info, e.g. ``"header"`` or ``"info0"``
+        :param force: If `True`, overwrite the cached header even if it
+            has not been changed, updating its cache timestamp.
+        """
+        if not (force or self.modified(sn, base)):
+            return
+
+        data = self._get(sn, base)
+        filename = self._makeFilename(sn, base)
+        dirname = os.path.dirname(filename)
+
+        try:
+            os.makedirs(dirname, exist_ok=True)
+        except IOError as err:
+            logger.error(f'Error creating cache directory {dirname}: {err!r}')
+            return
+
+        try:
+            with open(filename, 'wb') as f:
+                f.write(data)
+            self.setModified(base, sn, False)
+
+        except IOError as err:
+            logger.error(f'Error saving cache data {sn:08d}/{base}: {err!r}')
+
+
+    @synchronized
+    def revert(self, sn: int, base: str) -> Optional[bytes]:
+        """
+        Reload the last saved version of the cached data.
+
+        :param sn: The enDAQ device's serial number.
+        :param base: The name of the info, e.g. ``"header"`` or ``"info0"``
+        :return: The cached data, or `None` if no cache exists.
+        """
+        old = self._get(sn, base)
+        filename = self._makeFilename(sn, base)
+        
+        try:
+            with open(filename, 'rb') as f:
+                data = f.read()
+            self._set(sn, base, data)
+            self.setModified(base, sn, old and old != data)
+            return data
+        except FileNotFoundError:
+            return None
+        except IOError as err:
+            logger.error(f'Error loading file {filename}', exc_info=err)
+        
+
+    def getTimestamp(self, sn: int, base: str) -> float:
+        """
+        Get the date/time the cached data was last saved.
+
+        :param sn: The enDAQ device's serial number.
+        :param base: The name of the info, e.g. ``"header"`` or ``"info0"``
+        :return: The update's timestamp (UNIX epoch).
+        """
+        filename = self._makeFilename(sn, base)
+        try:
+            return os.path.getmtime(filename)
+        except FileNotFoundError:
+            pass
+        except IOError as err:
+            logger.error(f'Error getting timestamp of {filename}: {err!r}')
+            
+        return 0

--- a/endaq/device/mqtt/caching.py
+++ b/endaq/device/mqtt/caching.py
@@ -284,9 +284,10 @@ class FileCache(BaseCache):
                 pass
 
             try:
-                if time() - os.path.getmtime(filename) > limit:
-                    os.remove(filename)
-                    cleared.append((s, b, None))
+                with self._getLock(filename):
+                    if time() - os.path.getmtime(filename) > limit:
+                        os.remove(filename)
+                        cleared.append((s, b, None))
             except (IOError, OSError) as err:
                 cleared.append((s, b, err))
 

--- a/endaq/device/mqtt/manager.py
+++ b/endaq/device/mqtt/manager.py
@@ -37,6 +37,7 @@ from ..exceptions import CommandError, CRCError, DeviceError, ValidationError
 from ..util import getMyIP, makeClientID
 from .mqtt_interface import MQTT_BROKER, MQTT_PORT
 from .advertising import Advertiser
+from .caching import BaseCache, FileCache
 from .discovery import DEFAULT_NAME
 from .mqtt_client import MQTTClient
 from .mqtt_interface import STATE_TOPIC, HEADER_TOPIC, MEASUREMENT_TOPIC, COMMAND_TOPIC
@@ -389,37 +390,15 @@ class MQTTDevice:
                          f'to {self.headerTopic}: {err!r}')
 
 
-    def _getCacheFile(self,
-                      create: bool = True) -> str:
-        """ Get the full path to this device's cached header data. The file
-            may or may not exist.
-
-            :param create: If `True`, create the directories for the
-                cache files. Mainly for use when saving.
-            :return: The full path to the cache file.
-        """
-        if create:
-            os.makedirs(self.manager.cachePath, exist_ok=True)
-        return os.path.join(self.manager.cachePath, f'{self.sn}_header.ide')
-
-
     def loadHeader(self) -> bytes:
         """ Load cached header data, if available.
 
             :return: Encoded EBML data containing the header of an IDE
                 file, or `None` if no cached header is available.
         """
-        try:
-            filename = self._getCacheFile(create=False)
-            if os.path.exists(filename):
-                with open(filename, 'rb') as f:
-                    header = f.read()
-                logger.debug(f'Loaded cached header for {self.sn} ({len(header)} bytes)')
-                return header
-        except IOError:
-            logger.error('Error loading header data', exc_info=True)
-
-        return None
+        header = self.manager.cache.get(self.sn, 'header')
+        logger.debug(f'Loaded cached header for {self.sn} ({len(header)} bytes)')
+        return header
 
 
     def saveHeader(self, data: bytes) -> None:
@@ -429,12 +408,7 @@ class MQTTDevice:
                 file.
         """
         logger.debug(f'Saving header data for {self.sn} ({len(data)} bytes)')
-        try:
-            filename = self._getCacheFile(create=True)
-            with open(filename, 'wb') as f:
-                f.write(data)
-        except IOError:
-            logger.error('Error saving header data', exc_info=True)
+        self.manager.cache.set(self.sn, 'header', data)
 
 
     @synchronized
@@ -477,7 +451,7 @@ class MQTTDeviceManager(MQTTClient):
                  make_crc: bool = True,
                  ignore_crc: bool = False,
                  interval: int = 45,
-                 cache: Union[str, Path] = CACHE_PATH,
+                 cache: Union[str, Path, BaseCache] = CACHE_PATH,
                  shutdown: bool = False):
         """ A client that monitors several MQTT topics, providing additional
             features for device discovery and data streaming.
@@ -489,7 +463,8 @@ class MQTTDeviceManager(MQTTClient):
                 or responses.
             :param interval: The time between published `state` updates. If
                 0, no `state` updates will be published.
-            :param cache: The path to the directory where cached data is stored.
+            :param cache: The location for cached device data, either a
+                directory or an instance of a `BaseCache` storage handler.
             :param shutdown: If `True`, the manager can be shut down remotely
                 via the ``Shutdown`` EBML command.
         """
@@ -499,7 +474,11 @@ class MQTTDeviceManager(MQTTClient):
 
         type(self).__instances__.add(self)
 
-        self.cachePath = cache
+        if isinstance(cache, (str, Path)):
+            self.cache = FileCache(cache)
+        else:
+            self.cachePath = cache
+
         self.allowShutdown = shutdown
 
         self.knownDevices: dict[int, MQTTDevice] = {}
@@ -616,26 +595,17 @@ class MQTTDeviceManager(MQTTClient):
                 modified in `retention` hours will be removed.
         """
         logger.debug(f'MQTTDeviceManager.cleanCache: Clearing cached headers '
-                     f'older than {retention} hours from "{self.cachePath}"...')
-        limit = retention * 60 * 60
-        errs = []
-        cleared = []
-        if os.path.isdir(self.cachePath):
-            for f in os.listdir(self.cachePath):
-                if f.lower().endswith('_header.ide'):
-                    try:
-                        filename = os.path.join(self.cachePath, f)
-                        if time() - os.path.getmtime(filename) > limit:
-                            os.remove(filename)
-                            cleared.append(filename)
-                    except (IOError, OSError) as err:
-                        errs.append(err)
+                     f'older than {retention} hours')
 
-        logger.debug(f'MQTTDeviceManager.cleanCache: {len(cleared)} files deleted, '
-                     f'{len(errs)} failed.')
+        items = self.cache.cleanCache(None, 'header', retention)
+        cleared = [f for f in items if f[-1] is None]
+        errs = [f for f in items if f[-1] is not None]
+
+        logger.debug(f'MQTTDeviceManager.cleanCache: {len(cleared)} '
+                     f'cached items deleted, {len(errs)} failed.')
         if errs:
             logger.error(f'MQTTDeviceManager.cleanCache failed to remove '
-                         f'some cached files: {errs!r}')
+                         f'some cached items: {errs!r}')
 
         return cleared, errs
 

--- a/endaq/device/mqtt/manager.py
+++ b/endaq/device/mqtt/manager.py
@@ -321,7 +321,7 @@ class MQTTDevice:
                          exc_info=True)
 
 
-    def validateHeader(self, data: bytes) -> Union[bool, Dict[str, Any]]:
+    def validateHeader(self, data: bytes) -> Dict[str, Any]:
         """ Verify that header data is complete and valid. Raises a
             `ValidationError` if validation fails.
 


### PR DESCRIPTION
The mechanism for managing cached data has been refactored; it is now abstracted rather than explicitly reading/writing files. The default cache manager still uses files, but it can be easily replaced with something else (e.g., a database) if need be.