### PR TITLE
Thread safety improvements

### DIFF
--- a/endaq/device/base.py
+++ b/endaq/device/base.py
@@ -13,7 +13,6 @@ import os
 from pathlib import Path
 import re
 import sys
-from threading import RLock
 from time import struct_time
 from typing import Any, AnyStr, Callable, Dict, List, Optional, Tuple, Union
 import warnings
@@ -44,6 +43,7 @@ from .command_interfaces import CommandInterface
 from .exceptions import *
 from .types import Drive, Filename, Epoch
 from . import util
+from .util import synchronized
 
 logger = logging.getLogger(__name__)
 
@@ -117,7 +117,6 @@ class Recorder:
             :param virtual: `True` if the device is not actual hardware
                 (e.g., constructed from data in a recording).
         """
-        self._busy = RLock()
         self.strict: bool = strict
 
         self._virtual: bool = virtual
@@ -174,6 +173,7 @@ class Recorder:
         self._lastCommandID: int = None
 
 
+    @synchronized
     def _getDevinfo(self) -> DeviceInfo:
         """ Retrieve the appropriate `DeviceInfo` for the `Recorder`.
         """
@@ -194,6 +194,7 @@ class Recorder:
 
 
     @property
+    @synchronized
     def command(self) -> Union[None, command_interfaces.CommandInterface]:
         """ The device's "command interface," the means through which to
             directly control the device. Only applicable to non-virtual
@@ -206,29 +207,27 @@ class Recorder:
         if self.isVirtual:
             raise UnsupportedFeature("Virtual devices cannot execute commands")
 
-        with self._busy:
+        if self._command is None:
+            for interface in command_interfaces.INTERFACES:
+                if interface.hasInterface(self):
+                    # logger.debug('Instantiating command interface: {!r}'.format(interface))
+                    self._command = interface(self)
+                    break
+
             if self._command is None:
-                for interface in command_interfaces.INTERFACES:
-                    if interface.hasInterface(self):
-                        # logger.debug('Instantiating command interface: {!r}'.format(interface))
-                        self._command = interface(self)
-                        break
+                raise UnsupportedFeature("Device has no command interface")
 
-                if self._command is None:
-                    raise UnsupportedFeature("Device has no command interface")
-
-            return self._command
+        return self._command
 
 
     @command.setter
+    @synchronized
     def command(self, interface: Optional[command_interfaces.CommandInterface]):
-        with self._busy:
-            if interface == self._command:
-                return
-            if self._command is not None:
-                with self._busy:
-                    self._command.close()
-            self._command = interface
+        if interface == self._command:
+            return
+        elif self._command is not None:
+            self._command.close()
+        self._command = interface
 
 
     @property
@@ -244,6 +243,7 @@ class Recorder:
 
 
     @property
+    @synchronized
     def available(self) -> bool:
         """ Is the device mounted and available as a drive? Note: if the
             device's path or drive letter changed (e.g., after being rebooted
@@ -251,26 +251,36 @@ class Recorder:
             manifest was updated, you may need to call
             :meth:`~.endaq.device.Recorder.update` first.
         """
-        if self.isVirtual or not self.path:
+        if self.isVirtual or self.isRemote:
             return False
 
         # Two checks, since former is a property that sets latter
         # and path itself isn't a reliable test in Linux
-        if (os.path.exists(self.path) and os.path.isfile(self.infoFile)):
-            # See if the device is mounted in the same place and is unchanged.
-            try:
+        try:
+            if (os.path.exists(self.path) and os.path.isfile(self.infoFile)):
+                # See if the device is mounted in the same place and is unchanged.
                 return self._getHash(self.path) == hash(self)
-            except IOError as err:
-                if err.errno == errno.EINVAL:
-                    # Possible race condition: device dismounts after test.
-                    logger.debug('Ignoring expected IOError (EINVAL) getting hash '
-                                 '(device dismounting?)')
-                    return False
+
+        except IOError as err:
+            if err.errno == errno.EINVAL:
+                # Possible race condition: device dismounts after test.
+                logger.debug('Ignoring expected IOError (EINVAL) getting hash '
+                             '(device dismounting?)')
+            else:
+                raise
+
+        except TypeError as err:
+            if not self.path:
+                logger.debug('Recorder.available: no device path (race condition?), ignoring')
+            elif 'None' in str(err):
+                logger.debug('Recorder.available: no device infoFile (race condition?), ignoring')
+            else:
                 raise
 
         return False
 
 
+    @synchronized
     def update(self,
                virtual: bool = False,
                paths: Optional[List[Filename]] = None,
@@ -326,6 +336,7 @@ class Recorder:
         return path != self.path
 
 
+    @synchronized
     def __repr__(self) -> str:
         """ Return repr(self). """
         if self.isVirtual:
@@ -357,117 +368,118 @@ class Recorder:
         return hash(info)
 
 
+    @synchronized
     def __hash__(self) -> int:
         """ Return hash(self). """
-        with self._busy:
-            if self._hash is None:
-                self.getInfo()
-            return self._hash
+        if self._hash is None:
+            self.getInfo()
+        return self._hash
 
 
+    @synchronized
     def refresh(self, force: bool = False):
         """ Clear cached device information, ensuring the data is up-to-date.
 
             :param force: If `True`, reread information from the device,
                 rather than use cached data.
         """
-        with self._busy:
-            # Data derived from DEVINFO
-            self._devinfo = None
-            self._info = None
-            self._hash = None
+        # Data derived from DEVINFO
+        self._devinfo = None
+        self._info = None
+        self._hash = None
 
-            if not self.isRemote:
-                # Also from DEVINFO, but required for finding remote devices.
-                # Outside of manufacturing, the device SN shouldn't change.
-                self._sn = None
-                self._snInt = None
-                self._chipId = None
+        if not self.isRemote:
+            # Also from DEVINFO, but required for finding remote devices.
+            # Outside of manufacturing, the device SN shouldn't change.
+            self._sn = None
+            self._snInt = None
+            self._chipId = None
 
-            if not self.isVirtual:
-                # Data derived from things virtual devices can't read; virtual
-                # devices only get a subset of this data upon instantiation
-                if force:
-                    self._rawinfo = None
+        if not self.isVirtual:
+            # Data derived from things virtual devices can't read; virtual
+            # devices only get a subset of this data upon instantiation
+            if force:
+                self._rawinfo = None
 
-                self._sensors = None
-                self._channels = None
-                self._channelRanges.clear()
-                self._configData = None
-                self._propData = None
-                self._manifest = None
-                self._calibration = None
-                self._calData = None
-                self._calPolys = None
-                self._userCalPolys = None
-                self._userCalDict = None
-                self._factoryCalPolys = None
-                self._factoryCalDict = None
-                self._properties = None
-                self._volumeName = None
-                self._wifi = None
-            else:
-                self.getInfo()
+            self._sensors = None
+            self._channels = None
+            self._channelRanges.clear()
+            self._configData = None
+            self._propData = None
+            self._manifest = None
+            self._calibration = None
+            self._calData = None
+            self._calPolys = None
+            self._userCalPolys = None
+            self._userCalDict = None
+            self._factoryCalPolys = None
+            self._factoryCalDict = None
+            self._properties = None
+            self._volumeName = None
+            self._wifi = None
+        else:
+            self.getInfo()
 
-            if self._command:
-                try:
-                    self._command.close()
-                except (AttributeError, IOError) as err:
-                    logger.debug('Ignoring exception closing {}: '
-                                 '{!r}'.format(self._command, err))
-                self._command = None
+        if self._command:
+            try:
+                self._command.close()
+            except (AttributeError, IOError) as err:
+                logger.debug('Ignoring exception closing {}: '
+                             '{!r}'.format(self._command, err))
+            self._command = None
 
-            if self._config:
-                try:
-                    self._config.close()
-                except (AttributeError, IOError) as err:
-                    logger.debug('Ignoring exception closing {}: '
-                                 '{!r}'.format(self._config, err))
-                self._config = None
+        if self._config:
+            try:
+                self._config.close()
+            except (AttributeError, IOError) as err:
+                logger.debug('Ignoring exception closing {}: '
+                             '{!r}'.format(self._config, err))
+            self._config = None
 
 
     @property
+    @synchronized
     def path(self) -> Union[str, None]:
         """ The recorder's filesystem path (e.g., drive letter or mount point).
         """
-        with self._busy:
-            return self._path
+        return self._path
 
 
     @path.setter
+    @synchronized
     def path(self, newpath: Union[Filename, None]):
         """ The recorder's filesystem path (e.g., drive letter or mount point).
         """
-        with self._busy:
-            path = None
-            self._volumeName = ''
-            self.configFile = self.infoFile = None
-            self.clockFile = self.userCalFile = self.configUIFile = None
-            self.recpropFile = self.commandFile = None
+        path = None
+        self._volumeName = ''
+        self.configFile = self.infoFile = None
+        self.clockFile = self.userCalFile = self.configUIFile = None
+        self.recpropFile = self.commandFile = None
 
-            if str(newpath).lower().startswith(('mqtt', 'remote')):
-                path = newpath
+        if str(newpath).lower().startswith(('mqtt', 'remote')):
+            path = newpath
 
-            elif newpath is not None:
-                newpath = newpath.path if isinstance(newpath, Drive) else newpath
-                if self.strict and not self.isRecorder(newpath):
-                    raise IOError("Specified path isn't a %s: %r" %
-                                  (self.__class__.__name__, newpath))
+        elif newpath is not None:
+            newpath = newpath.path if isinstance(newpath, Drive) else newpath
+            if self.strict and not self.isRecorder(newpath):
+                raise IOError("Specified path isn't a %s: %r" %
+                              (self.__class__.__name__, newpath))
 
-                path = os.path.realpath(newpath)
-                self.configFile = os.path.join(path, self._CONFIG_FILE)
-                self.infoFile = os.path.join(path, self._INFO_FILE)
-                self.clockFile = os.path.join(path, self._CLOCK_FILE)
-                self.userCalFile = os.path.join(path, self._USERCAL_FILE)
-                self.configUIFile = os.path.join(path, self._CONFIG_UI_FILE)
-                self.recpropFile = os.path.join(path, self._RECPROP_FILE)
-                self.commandFile = os.path.join(path, self._COMMAND_FILE)
-                self._volumeName = None
+            path = os.path.realpath(newpath)
+            self.configFile = os.path.join(path, self._CONFIG_FILE)
+            self.infoFile = os.path.join(path, self._INFO_FILE)
+            self.clockFile = os.path.join(path, self._CLOCK_FILE)
+            self.userCalFile = os.path.join(path, self._USERCAL_FILE)
+            self.configUIFile = os.path.join(path, self._CONFIG_UI_FILE)
+            self.recpropFile = os.path.join(path, self._RECPROP_FILE)
+            self.commandFile = os.path.join(path, self._COMMAND_FILE)
+            self._volumeName = None
 
-            self._path = path
+        self._path = path
 
 
     @property
+    @synchronized
     def volumeName(self) -> Union[str, bool]:
         """ The recorder's user-specified filesystem label. """
         if self.isVirtual or self.isRemote:
@@ -579,6 +591,7 @@ class Recorder:
             return False
 
 
+    @synchronized
     def getInfo(self,
                 name: Optional[str] = None,
                 default=None) -> Any:
@@ -594,49 +607,47 @@ class Recorder:
                 device data. If a `name` is specified, the type returned will
                 vary.
         """
-        mideSchema = loadSchema("mide_ide.xml")
-        with self._busy:
-            if not self._info:
-                if not self._rawinfo:
-                    try:
-                        self._rawinfo = self._getDevinfo().readDevinfo(self.path)
-                    except DeviceError:
-                        # Serial/MQTT _getInfo() command failed
-                        # TODO: This may not be necessary, depending on how remote devices are handled (in progress)
-                        pass
-                if self._rawinfo:
-                    self._hash = hash(self._rawinfo)
-                    infoFile = mideSchema.loads(self._rawinfo)
-                    try:
-                        props = infoFile.dump().get('RecordingProperties', {})
-                        self._info = props.get('RecorderInfo', {})
-                        for k, v in self._info.items():
-                            if isinstance(v, bytes):
-                                # Nothing in the device info should be binary,
-                                # but as of ebmlite 3.0.1, StringElements are
-                                # read as bytes. Convert.
-                                self._info[k] = str(v, 'utf8')
-                    except (IOError, KeyError) as err:
-                        logger.debug("getInfo() raised a possibly-allowed exception: %r" % err)
-                        pass
-                    finally:
-                        infoFile.close()
+        if not self._info:
+            if not self._rawinfo:
+                try:
+                    self._rawinfo = self._getDevinfo().readDevinfo(self.path)
+                except DeviceError:
+                    # Serial/MQTT _getInfo() command failed
+                    # TODO: This may not be necessary, depending on how remote devices are handled (in progress)
+                    pass
+            if self._rawinfo:
+                self._hash = hash(self._rawinfo)
+                infoFile = loadSchema("mide_ide.xml").loads(self._rawinfo)
+                try:
+                    props = infoFile.dump().get('RecordingProperties', {})
+                    self._info = props.get('RecorderInfo', {})
+                    for k, v in self._info.items():
+                        if isinstance(v, bytes):
+                            # Nothing in the device info should be binary,
+                            # but as of ebmlite 3.0.1, StringElements are
+                            # read as bytes. Convert.
+                            self._info[k] = str(v, 'utf8')
+                except (IOError, KeyError) as err:
+                    logger.debug("getInfo() raised a possibly-allowed exception: %r" % err)
+                    pass
+                finally:
+                    infoFile.close()
 
-            if not self._hash:
-                # Probably a virtual device (from IDE file); use _info dict.
-                # FUTURE: base hash on IDE?
-                self._hash = hash(repr(self._info))
+        if not self._hash:
+            # Probably a virtual device (from IDE file); use _info dict.
+            # FUTURE: base hash on IDE?
+            self._hash = hash(repr(self._info))
 
-            if not self._info:
-                if name is None:
-                    return {}
-                return default
-
+        if not self._info:
             if name is None:
-                # Whole dict requested: return a copy (prevents accidental edits)
-                return self._info.copy()
-            else:
-                return self._info.get(name, default)
+                return {}
+            return default
+
+        if name is None:
+            # Whole dict requested: return a copy (prevents accidental edits)
+            return self._info.copy()
+        else:
+            return self._info.get(name, default)
 
 
     @property
@@ -646,6 +657,7 @@ class Recorder:
 
 
     @property
+    @synchronized
     def isRemote(self) -> bool:
         """ Is this device not directly connected to this computer? """
         if self.isVirtual:
@@ -656,6 +668,7 @@ class Recorder:
 
 
     @property
+    @synchronized
     def name(self) -> str:
         """ The recording device's (user-assigned) name. """
         if self._name:
@@ -667,6 +680,7 @@ class Recorder:
 
 
     @property
+    @synchronized
     def notes(self) -> str:
         """ The recording device's (user-assigned) description. """
         try:
@@ -811,6 +825,7 @@ class Recorder:
 
 
     @property
+    @synchronized
     def hasWifi(self) -> Union[str, bool]:
         """ The name of the Wi-Fi hardware type, or `False` if none. The name
             will not be blank, so expressions like `if dev.hasWifi:` will work.
@@ -971,6 +986,7 @@ class Recorder:
                 for chId, subChs in channels.items()}
 
 
+    @synchronized
     def getTime(self,
                 epoch=True,
                 timeout: Union[int, float] = 3) -> Union[Tuple[datetime, datetime], Tuple[Epoch, Epoch]]:
@@ -995,6 +1011,7 @@ class Recorder:
         return ci.getTime(epoch=epoch, timeout=timeout)
 
 
+    @synchronized
     def setTime(self,
                 t: Union[Epoch, datetime, struct_time, tuple, None] = None,
                 pause: bool = True,
@@ -1030,6 +1047,7 @@ class Recorder:
         return ci.setTime(t=t, pause=pause, retries=retries, timeout=timeout)
 
 
+    @synchronized
     def getClockDrift(self,
                       pause: bool = True,
                       retries: int = 1,
@@ -1074,6 +1092,7 @@ class Recorder:
             return {}
 
 
+    @synchronized
     def getManifest(self) -> Union[Dict[str, Any], None]:
         """ Read the device's manifest data. The data is a superset of the
             information returned by `getInfo()`.
@@ -1081,42 +1100,42 @@ class Recorder:
         # Note: This method sets `Recorder._propData`, `Recorder._manData`,
         # `Recorder._calData`, `Recorder._manifest`, and `Recorder._calibration`.
 
-        with self._busy:
-            if self._manifest is not None or self.isVirtual:
-                return self._manifest
-
-            manSchema = loadSchema('mide_manifest.xml')
-            calSchema = loadSchema('mide_ide.xml')
-            manData, calData, propData = self._getDevinfo().readManifest()
-
-            if manData:
-                self._manData = manData
-                try:
-                    self._manifest = manSchema.loads(manData)[0].dump()
-                except IndexError:
-                    logger.warning(f'No manifest data for {self}!')
-                    self._manifest = None
-            else:
-                logger.warning(f'No manifest data for {self}!')
-                self._manData = self._manifest = None
-
-            if calData:
-                self._calData = calSchema.loads(calData)
-                try:
-                    self._calibration = self._calData[0].dump()
-                except IndexError:
-                    logger.warning(f'No system calibration for {self}!')
-                    self._calibration = None
-            else:
-                logger.warning(f'No system calibration for {self}!')
-                self._calData = self._calibration = None
-
-            if propData:
-                self._propData = propData
-
+        if self._manifest is not None or self.isVirtual:
             return self._manifest
 
+        manSchema = loadSchema('mide_manifest.xml')
+        calSchema = loadSchema('mide_ide.xml')
+        manData, calData, propData = self._getDevinfo().readManifest()
 
+        if manData:
+            self._manData = manData
+            try:
+                self._manifest = manSchema.loads(manData)[0].dump()
+            except IndexError:
+                logger.warning(f'No manifest data for {self}!')
+                self._manifest = None
+        else:
+            logger.warning(f'No manifest data for {self}!')
+            self._manData = self._manifest = None
+
+        if calData:
+            self._calData = calSchema.loads(calData)
+            try:
+                self._calibration = self._calData[0].dump()
+            except IndexError:
+                logger.warning(f'No system calibration for {self}!')
+                self._calibration = None
+        else:
+            logger.warning(f'No system calibration for {self}!')
+            self._calData = self._calibration = None
+
+        if propData:
+            self._propData = propData
+
+        return self._manifest
+
+
+    @synchronized
     def _readCalFile(self,
                      filename: Optional[Filename] = None) -> Optional[MasterElement]:
         """ Read a file of calibration data.
@@ -1307,6 +1326,7 @@ class Recorder:
         return self._properties
 
 
+    @synchronized
     def getSensors(self) -> Dict[int, Sensor]:
         """ Get the recorder sensor description data.
         """
@@ -1484,28 +1504,28 @@ class Recorder:
     # ===========================================================================
 
     @property
+    @synchronized
     def config(self) -> ConfigInterface:
         """ The device's "configuration interface," the means through which to
             read and/or write device config.
         """
-        with self._busy:
+        if self._config is None:
+            for interface in config.INTERFACES:
+                if interface.hasInterface(self):
+                    # logger.debug('Instantiating config interface: {!r}'.format(interface))
+                    self._config = interface(self)
+                    break
+
             if self._config is None:
-                for interface in config.INTERFACES:
-                    if interface.hasInterface(self):
-                        # logger.debug('Instantiating config interface: {!r}'.format(interface))
-                        self._config = interface(self)
-                        break
+                raise UnsupportedFeature("Device has no configuration interface")
 
-                if self._config is None:
-                    raise UnsupportedFeature("Device has no configuration interface")
-
-            return self._config
+        return self._config
 
 
     @config.setter
+    @synchronized
     def config(self, interface: ConfigInterface):
-        with self._busy:
-            self._config = interface
+        self._config = interface
 
 
     @property

--- a/endaq/device/client.py
+++ b/endaq/device/client.py
@@ -7,7 +7,6 @@ software in the enDAQ ecosystem.
 """
 
 from functools import wraps
-from threading import RLock, get_native_id
 from time import time
 from typing import Any, ByteString, Dict, Optional, Tuple, Union
 
@@ -18,50 +17,12 @@ logger = logging.getLogger(__name__)
 
 from .command_interfaces import SerialCommandInterface, CommandError, CRCError, CommandInterface
 from .response_codes import DeviceStatusCode
-from .util import dump
+from .util import dump, synchronized
 
 
 # ===========================================================================
 #
 # ===========================================================================
-
-def synchronized(method):
-    """ Decorator for making methods use a lock, modeled after the one in
-        Java. It uses `threading.RLock`; synchronized methods called from
-        the same thread that has claimed the lock are not blocked.
-    """
-    @wraps(method)
-    def wrapped(instance, *args, **kwargs):
-        try:
-            lock = instance._synchronized_lock
-        except AttributeError:
-            lock = instance._synchronized_lock = RLock()
-        with lock:
-            return method(instance, *args, **kwargs)
-    return wrapped
-
-
-def _synchronized(method):
-    """ Decorator for making methods use a lock, modeled after the one in
-        Java. This version does some debug logging.
-    """
-    @wraps(method)
-    def wrapped(instance, *args, **kwargs):
-        try:
-            lock = instance._synchronized_lock
-        except AttributeError:
-            lock = instance._synchronized_lock = RLock()
-        with lock:
-            # Don't log the `in_waiting` property checks (too many calls)
-            if 'waiting' not in str(method):
-                logger.debug(f'>>> calling synchronized method {method} (thread {get_native_id()})')
-            try:
-                return method(instance, *args, **kwargs)
-            finally:
-                if 'waiting' not in str(method):
-                    logger.debug(f'<<< exiting synchronized method {method} (thread {get_native_id()})')
-    return wrapped
-
 
 def requires_lock(method):
     """ Decorator for command methods that require a `LockID`. It is

--- a/endaq/device/command_interfaces.py
+++ b/endaq/device/command_interfaces.py
@@ -31,8 +31,9 @@ from .exceptions import CRCError
 from .types import Epoch, Filename
 from . import response_codes
 from .response_codes import *
-from . import util
 from . import updating
+from . import util
+from .util import device_synchronized
 
 if sys.platform == 'darwin':
     from . import macos as os_specific
@@ -359,6 +360,7 @@ class CommandInterface:
         raise NotImplementedError
 
 
+    @device_synchronized
     def getTime(self,
                 epoch: bool = True,
                 timeout: Union[int, float] = 3
@@ -373,8 +375,7 @@ class CommandInterface:
                 raising a `TimeoutError`. Not used by all interface types.
             :return: The system time and the device time. Both are UTC.
         """
-        with self.device._busy:
-            sysTime, devTime = self._getTime(pause=False, timeout=timeout)
+        sysTime, devTime = self._getTime(pause=False, timeout=timeout)
 
         if epoch:
             return sysTime, devTime
@@ -383,6 +384,7 @@ class CommandInterface:
                 util.utcfromtimestamp(devTime))
 
 
+    @device_synchronized
     def setTime(self,
                 t: Union[Epoch, datetime, struct_time, tuple, None] = None,
                 pause: bool = True,
@@ -412,18 +414,18 @@ class CommandInterface:
             pause = False
             t = util.time2epoch(t)
 
-        with self.device._busy:
-            try:
-                return self._setTime(t, pause=pause)
-            except IOError:
-                if retries > 0:
-                    sleep(.5)
-                    return self.setTime(pause=pause, retries=retries - 1,
-                                        timeout=timeout)
-                else:
-                    raise
+        try:
+            return self._setTime(t, pause=pause)
+        except IOError:
+            if retries > 0:
+                sleep(.5)
+                return self.setTime(pause=pause, retries=retries - 1,
+                                    timeout=timeout)
+            else:
+                raise
 
 
+    @device_synchronized
     def getClockDrift(self,
                       pause: bool = True,
                       retries: int = 1,
@@ -441,18 +443,17 @@ class CommandInterface:
                 is `True`, before raising a `TimeoutError`.
             :return: The length of the drift, in seconds.
         """
-        with self.device._busy:
-            try:
-                sysTime, devTime = self._getTime(pause=True, timeout=timeout)
-                return sysTime - devTime
-            except IOError:
-                if retries > 0:
-                    sleep(.25)
-                    return self.getClockDrift(pause=pause,
-                                              retries=retries - 1,
-                                              timeout=timeout)
-                else:
-                    raise
+        try:
+            sysTime, devTime = self._getTime(pause=True, timeout=timeout)
+            return sysTime - devTime
+        except IOError:
+            if retries > 0:
+                sleep(.25)
+                return self.getClockDrift(pause=pause,
+                                          retries=retries - 1,
+                                          timeout=timeout)
+            else:
+                raise
 
 
     def _setStatus(self,
@@ -826,8 +827,7 @@ class CommandInterface:
             return False
 
         def dismounted():
-            with self.device._busy:
-                return not self.device.available
+            return not self.device.available
 
         try:
             return util.waitfor(dismounted, timeout=timeout, interval=0.1,
@@ -874,10 +874,9 @@ class CommandInterface:
             return False
 
         def remounted():
-            with self.device._busy:
-                if update:
-                    self.device.update(paths=paths, strict=strict)
-                return self.device.available
+            if update:
+                self.device.update(paths=paths, strict=strict)
+            return self.device.available
 
         try:
             return util.waitfor(remounted, timeout=timeout,
@@ -910,8 +909,7 @@ class CommandInterface:
             return False
 
         def disconnected():
-            with self.device._busy:
-                return not self.available
+            return not self.available
 
         try:
             return util.waitfor(disconnected,
@@ -943,8 +941,7 @@ class CommandInterface:
             return False
 
         def available() -> bool:
-            with self.device._busy:
-                return self.available
+            return self.available
 
         try:
             return util.waitfor(available, timeout, 0.25, callback)
@@ -953,13 +950,15 @@ class CommandInterface:
 
 
     def _updateAll(self,
-                   secure: True,
+                   secure: bool = True,
                    wait: bool = True,
                    timeout: Union[int, float] = 10,
                    callback: Optional[Callable] = None) -> bool:
         """ Send interface-specific update command. Implemented for each
             subclass.
 
+            :param secure: if `True`, use the secure update command (requires
+                encrypted firmware).
             :param wait: If `True`, wait for the recorer to dismount,
                 indicating the update has started.
             :param timeout: Time (in seconds) to wait for the recorder to
@@ -1011,6 +1010,7 @@ class CommandInterface:
         return os.path.isfile(dest)
 
 
+    @device_synchronized
     def updateDevice(self,
                      firmware: Optional[str] = None,
                      userpage: Optional[str] = None,
@@ -1083,27 +1083,26 @@ class CommandInterface:
             if validate:
                 updating.validateUserpage(self, userpage)
 
-        with self.device._busy:
-            hasFw = self._copyUpdateFile(firmware, fw, clean)
-            hasUp = self._copyUpdateFile(userpage, up, clean)
+        hasFw = self._copyUpdateFile(firmware, fw, clean)
+        hasUp = self._copyUpdateFile(userpage, up, clean)
 
-            if not (hasFw or hasUp):
-                raise FileNotFoundError(errno.ENOENT,
-                                        "Device has no update files",
-                                        os.path.dirname(fw))
+        if not (hasFw or hasUp):
+            raise FileNotFoundError(errno.ENOENT,
+                                    "Device has no update files",
+                                    os.path.dirname(fw))
 
-            isPkg = hasFw and fw_ext == ".pkg"
-            signature = None if firmware is None or not isPkg else firmware + ".sig"
+        isPkg = hasFw and fw_ext == ".pkg"
+        signature = None if firmware is None or not isPkg else firmware + ".sig"
 
-            if isPkg and not self._copyUpdateFile(signature, sig, clean):
-                raise FileNotFoundError(errno.ENOENT,
-                                        "Firmware signature file not found",
-                                        (signature or sig))
+        if isPkg and not self._copyUpdateFile(signature, sig, clean):
+            raise FileNotFoundError(errno.ENOENT,
+                                    "Firmware signature file not found",
+                                    (signature or sig))
 
-            # Use 'secure' if the device FW update is a .pkg, or it has keys installed.
-            secure = bool(isPkg or keyRev)
+        # Use 'secure' if the device FW update is a .pkg, or it has keys installed.
+        secure = bool(isPkg or keyRev)
 
-            return self._updateAll(secure=secure, timeout=timeout, callback=callback)
+        return self._updateAll(secure=secure, timeout=timeout, callback=callback)
 
 
     def setKeys(self,
@@ -1131,6 +1130,7 @@ class CommandInterface:
     # Wi-Fi
     # =======================================================================
 
+    @device_synchronized
     def setAP(self,
               ssid: str,
               password: Optional[str] = None,
@@ -1162,25 +1162,24 @@ class CommandInterface:
         if password is not None:
             cmd['Password'] = password
 
-        with self.device._busy:
-            self.setWifi(cmd, timeout=timeout, callback=callback)
-            if not wait or timeout == 0:
+        self.setWifi(cmd, timeout=timeout, callback=callback)
+        if not wait or timeout == 0:
+            return None
+
+        while timeout < 0 or time() < deadline:
+            if callback is not None and callback():
                 return None
 
-            while timeout < 0 or time() < deadline:
-                if callback is not None and callback():
+            response = self.queryWifi(timeout=0.5)
+            if response:
+                status = response.get('WiFiConnectionStatus')
+                if status == WiFiConnectionStatus.CONNECTED:
                     return None
+            else:
+                logger.debug('setAP(): got bad queryWifi() response: {!r}'
+                             .format(response))
 
-                response = self.queryWifi(timeout=0.5)
-                if response:
-                    status = response.get('WiFiConnectionStatus')
-                    if status == WiFiConnectionStatus.CONNECTED:
-                        return None
-                else:
-                    logger.debug('setAP(): got bad queryWifi() response: {!r}'
-                                 .format(response))
-
-                sleep(min(timeout, 0.5))
+            sleep(min(timeout, 0.5))
 
         raise DeviceTimeout('Timed out waiting to connect to AP SSID {}'.format(ssid))
 
@@ -2055,6 +2054,7 @@ class SerialCommandInterface(CommandInterface):
         # raise TimeoutError("Timeout waiting for response to serial command")
 
 
+    @device_synchronized
     def _sendCommand(self,
                      cmd: dict,
                      response: bool = True,
@@ -2091,109 +2091,107 @@ class SerialCommandInterface(CommandInterface):
             :raise: DeviceTimeout
         """
         timeout = -1 if timeout is None else timeout
-        deadline = time() + timeout
+        now = time()
+        deadline = now + timeout
 
-        with self.device._busy:
-            self.getSerialPort()
-            try:
-                now = time()
+        self.getSerialPort()
+        try:
+            if 'EBMLCommand' in cmd:
+                if index:
+                    self.index += 1
+                    cmd['EBMLCommand']['CommandIdx'] = self.index
+                if lock:
+                    cmd['EBMLCommand']['LockID'] = self.hostId or (b'\x00' * 16)
 
-                if 'EBMLCommand' in cmd:
-                    if index:
-                        self.index += 1
-                        cmd['EBMLCommand']['CommandIdx'] = self.index
-                    if lock:
-                        cmd['EBMLCommand']['LockID'] = self.hostId or (b'\x00' * 16)
+            packet = self._encode(cmd)
+            self.lastCommand = now, deepcopy(cmd)
+            self._writeCommand(packet)
 
-                packet = self._encode(cmd)
-                self.lastCommand = now, deepcopy(cmd)
-                self._writeCommand(packet)
+            if timeout == 0 and not response:
+                self.response = now, None, None
+                return None
 
-                if timeout == 0 and not response:
-                    self.response = now, None, None
-                    return None
-
-                while True:
-                    try:
-                        resp = self._readResponse(timeout, callback=callback)
-                    except (IOError, serial.SerialException) as err:
-                        # Commands that reset can cause the device to close the
-                        # port faster than the response can be read. Fail
-                        # gracefully if no response is required.
-                        if (not isinstance(err, serial.SerialException)
-                                and getattr(err, 'errno') != errno.EIO):
-                            # Linux (possibly other POSIX) raises IOError EIO (5)
-                            # if the port is gone. Raise if other errno.
-                            raise
-                        if not response:
-                            logger.debug('Ignoring anticipated exception because '
-                                         'response not required: {!r}'.format(err))
-                            self.response = now, None, None
-                            return None
-                        else:
-                            raise
-
-                    if resp:
-                        self._encodeResponseCodes(resp)
-                        responseCode = resp.get('CommandResponseCode')
-                        responseMsg = resp.get('CommandResponseMessage')
-                        statusCode = resp.get('DeviceStatusCode')
-                        statusMsg = resp.get('DeviceStatusMessage')
-                        queueDepth = resp.get('CMDQueueDepth', 1)
-
-                        # If either DeviceStatusCode or CommandResponseCode
-                        # are missing, default to whichever one exists.
-                        if responseCode is None:
-                            responseCode = statusCode
-                        elif statusCode is None:
-                            statusCode = responseCode
-                        if responseMsg is None:
-                            responseMsg = statusMsg
-                        elif statusMsg is None:
-                            statusMsg = responseMsg
-
-                        self._setStatus(responseCode, responseMsg,
-                                        statusCode, statusMsg,
-                                        resp.get('LockID'))
-
-                        if responseCode < 0:
-                            # Raise a CommandError or DeviceError. -20 and -30 refer
-                            # to bad commands sent by the user.
-                            EXC = CommandError if -30 <= responseCode <= -20 else DeviceError
-                            raise EXC(responseCode, responseMsg)
-
-                        if queueDepth == 0:
-                            logger.debug('Command queue full, retrying.')
-                        else:
-                            respIdx = resp.get('ResponseIdx', self.index)
-                            if not index or respIdx == self.index:
-                                return resp if response else None
-                            else:
-                                logger.debug('Bad ResponseIdx; expected {}, got {}. '
-                                             'Retrying.'.format(self.index, respIdx))
+            while True:
+                try:
+                    resp = self._readResponse(timeout, callback=callback)
+                except (IOError, serial.SerialException) as err:
+                    # Commands that reset can cause the device to close the
+                    # port faster than the response can be read. Fail
+                    # gracefully if no response is required.
+                    if (not isinstance(err, serial.SerialException)
+                            and getattr(err, 'errno') != errno.EIO):
+                        # Linux (possibly other POSIX) raises IOError EIO (5)
+                        # if the port is gone. Raise if other errno.
+                        raise
+                    if not response:
+                        logger.debug('Ignoring anticipated exception because '
+                                     'response not required: {!r}'.format(err))
+                        self.response = now, None, None
+                        return None
                     else:
-                        queueDepth = 1
+                        raise
 
-                    # Failure!
-                    if timeout > 0 and time() >= deadline:
-                        if not response:
-                            return None
-                        if queueDepth == 0:
-                            raise DeviceTimeout('Timed out waiting for opening in command queue')
+                if resp:
+                    self._encodeResponseCodes(resp)
+                    responseCode = resp.get('CommandResponseCode')
+                    responseMsg = resp.get('CommandResponseMessage')
+                    statusCode = resp.get('DeviceStatusCode')
+                    statusMsg = resp.get('DeviceStatusMessage')
+                    queueDepth = resp.get('CMDQueueDepth', 1)
+
+                    # If either DeviceStatusCode or CommandResponseCode
+                    # are missing, default to whichever one exists.
+                    if responseCode is None:
+                        responseCode = statusCode
+                    elif statusCode is None:
+                        statusCode = responseCode
+                    if responseMsg is None:
+                        responseMsg = statusMsg
+                    elif statusMsg is None:
+                        statusMsg = responseMsg
+
+                    self._setStatus(responseCode, responseMsg,
+                                    statusCode, statusMsg,
+                                    resp.get('LockID'))
+
+                    if responseCode < 0:
+                        # Raise a CommandError or DeviceError. -20 and -30 refer
+                        # to bad commands sent by the user.
+                        EXC = CommandError if -30 <= responseCode <= -20 else DeviceError
+                        raise EXC(responseCode, responseMsg)
+
+                    if queueDepth == 0:
+                        logger.debug('Command queue full, retrying.')
+                    else:
+                        respIdx = resp.get('ResponseIdx', self.index)
+                        if not index or respIdx == self.index:
+                            return resp if response else None
                         else:
-                            raise DeviceTimeout('Timed out waiting for command response')
-
-            except TimeoutError:
-                if not response:
-                    logger.debug('Ignoring timeout waiting for response '
-                                 'because no response required')
-                    self.response = now, None, None
-                    return None
+                            logger.debug('Bad ResponseIdx; expected {}, got {}. '
+                                         'Retrying.'.format(self.index, respIdx))
                 else:
-                    raise
+                    queueDepth = 1
 
-            finally:
-                self.port.close()
+                # Failure!
+                if timeout > 0 and time() >= deadline:
+                    if not response:
+                        return None
+                    if queueDepth == 0:
+                        raise DeviceTimeout('Timed out waiting for opening in command queue')
+                    else:
+                        raise DeviceTimeout('Timed out waiting for command response')
+
+        except TimeoutError:
+            if not response:
+                logger.debug('Ignoring timeout waiting for response '
+                             'because no response required')
+                self.response = now, None, None
+                return None
+            else:
+                raise
+
+        finally:
+            self.port.close()
 
 
     def _getTime(self,
@@ -2220,19 +2218,18 @@ class SerialCommandInterface(CommandInterface):
         #  should implement their own as well.
 
         command = {'EBMLCommand': {'GetClock': {}}}
-        with self.device._busy:
-            sysTime = t = time()
+        sysTime = t = time()
 
-            if pause:
-                while int(t) == int(sysTime):
-                    sysTime = time()
+        if pause:
+            while int(t) == int(sysTime):
+                sysTime = time()
 
-            response = self._sendCommand(command, timeout=timeout)
-            try:
-                dt = response['ClockTime']
-                devTime = self._TIME_PARSER.unpack_from(dt)[0]
-            except KeyError:
-                raise DeviceError("GetClock response did not contain ClockTime")
+        response = self._sendCommand(command, timeout=timeout)
+        try:
+            dt = response['ClockTime']
+            devTime = self._TIME_PARSER.unpack_from(dt)[0]
+        except KeyError:
+            raise DeviceError("GetClock response did not contain ClockTime")
 
         return sysTime, devTime
 
@@ -2542,6 +2539,7 @@ class SerialCommandInterface(CommandInterface):
                                       callback=callback)
 
 
+    @device_synchronized
     def getStatus(self,
                   timeout: Union[int, float] = 10,
                   callback: Optional[Callable] = None
@@ -2558,12 +2556,11 @@ class SerialCommandInterface(CommandInterface):
                 timestamp of the status update, the status code, and the
                 corresponding status message (if any).
         """
-        with self.device._busy:
-            self.ping(timeout=timeout, callback=callback)
-            if self._statusChanged.is_set():
-                self._statusChanged.clear()
-                return self.status
-            raise CommandError('Device responded but did not report its status')
+        self.ping(timeout=timeout, callback=callback)
+        if self._statusChanged.is_set():
+            self._statusChanged.clear()
+            return self.status
+        raise CommandError('Device responded but did not report its status')
 
 
     def _updateAll(self,
@@ -2574,6 +2571,8 @@ class SerialCommandInterface(CommandInterface):
         """ Send the 'secure update all' command, installing any userpage
             and/or firmware update files copied to the device.
 
+            :param secure: if `True`, use the secure update command (requires
+                encrypted firmware).
             :param wait: If `True`, wait for the recorer to dismount,
                 indicating the update has started.
             :param timeout: Time (in seconds) to wait for the recorder to
@@ -2647,6 +2646,7 @@ class SerialCommandInterface(CommandInterface):
     # Lock ID: A weakly-enforced means of claiming exclusive use of a device.
     # =======================================================================
 
+    @device_synchronized
     def getLockID(self,
                   timeout: Union[int, float] = 5,
                   callback: Optional[Callable] = None) -> Union[bytearray, bytes, None]:
@@ -2663,37 +2663,37 @@ class SerialCommandInterface(CommandInterface):
                 be cancelled. The callback function should require no arguments.
             :returns: The device's current lock ID, if any.
         """
-        with self.device._busy:
-            cmd = {'EBMLCommand': {'GetLockID': {}}}
+        cmd = {'EBMLCommand': {'GetLockID': {}}}
 
-            try:
-                response = self._sendCommand(cmd,
-                                             response=True,
-                                             timeout=timeout,
-                                             callback=callback)
-            except CommandError as err:
-                # Older FW returns wrong status code
-                if err.errno == DeviceStatusCode.ERR_INVALID_COMMAND:
-                    raise CommandError(DeviceStatusCode.ERR_UNKNOWN_COMMAND,
-                                       *err.args[1:])
-                raise
+        try:
+            response = self._sendCommand(cmd,
+                                         response=True,
+                                         timeout=timeout,
+                                         callback=callback)
+        except CommandError as err:
+            # Older FW returns wrong status code
+            if err.errno == DeviceStatusCode.ERR_INVALID_COMMAND:
+                raise CommandError(DeviceStatusCode.ERR_UNKNOWN_COMMAND,
+                                   *err.args[1:])
+            raise
 
-            if not response:
-                logger.debug('GetLockID did not get a response!')
-                return None
+        if not response:
+            logger.debug('GetLockID did not get a response!')
+            return None
 
-            lockId = response.get('LockID', None)
+        lockId = response.get('LockID', None)
 
-            if isinstance(lockId, (bytearray, bytes)) and not any(lockId):
-                # All zeros; lock not set.
-                return None
-            elif not lockId:
-                logger.debug('GetLockID response did not contain LockID!')
-                return None
+        if isinstance(lockId, (bytearray, bytes)) and not any(lockId):
+            # All zeros; lock not set.
+            return None
+        elif not lockId:
+            logger.debug('GetLockID response did not contain LockID!')
+            return None
 
-            return lockId
+        return lockId
 
 
+    @device_synchronized
     def setLockID(self,
                   current: Union[bytearray, bytes, None] = None,
                   new: Union[bytearray, bytes, None] = None,
@@ -2720,31 +2720,31 @@ class SerialCommandInterface(CommandInterface):
                 be cancelled. The callback function should require no arguments.
             :returns: The new lock ID.
         """
-        with self.device._busy:
-            lockId = new or self.hostId
-            if lockId == self.getLockID():
-                return True
-
-            cmd = {'EBMLCommand':
-                       {'SetLockID':
-                            {'CurrentLockID': current or (b'\x00' * 16),
-                             'NewLockID': lockId}}}
-
-            try:
-                self._sendCommand(cmd,
-                                  response=response,
-                                  timeout=timeout,
-                                  callback=callback)
-            except CommandError as err:
-                # Older FW returns wrong status code
-                if err.errno == DeviceStatusCode.ERR_INVALID_COMMAND:
-                    raise CommandError(DeviceStatusCode.ERR_UNKNOWN_COMMAND,
-                                       *err.args[1:])
-                raise
-
+        lockId = new or self.hostId
+        if lockId == self.getLockID():
             return True
 
+        cmd = {'EBMLCommand':
+                   {'SetLockID':
+                        {'CurrentLockID': current or (b'\x00' * 16),
+                         'NewLockID': lockId}}}
 
+        try:
+            self._sendCommand(cmd,
+                              response=response,
+                              timeout=timeout,
+                              callback=callback)
+        except CommandError as err:
+            # Older FW returns wrong status code
+            if err.errno == DeviceStatusCode.ERR_INVALID_COMMAND:
+                raise CommandError(DeviceStatusCode.ERR_UNKNOWN_COMMAND,
+                                   *err.args[1:])
+            raise
+
+        return True
+
+
+    @device_synchronized
     def clearLockID(self,
                     current: Union[bytearray, bytes, None] = None,
                     response: bool = True,
@@ -2768,13 +2768,12 @@ class SerialCommandInterface(CommandInterface):
                 be cancelled. The callback function should require no arguments.
         """
         # Same as setting with new=b'\x00\x00\x00...', but more user-friendly
-        with self.device._busy:
-            new = b'\00' * 16
-            current = current or self.hostId
-            result = bool(self.setLockID(new=new, current=current,
-                                         response=response, timeout=timeout,
-                                         callback=callback))
-            return result
+        new = b'\00' * 16
+        current = current or self.hostId
+        result = bool(self.setLockID(new=new, current=current,
+                                     response=response, timeout=timeout,
+                                     callback=callback))
+        return result
 
 
     # =======================================================================
@@ -2865,6 +2864,7 @@ class FileCommandInterface(CommandInterface):
     A mechanism for sending commands to a recorder via the `COMMAND` file.
     """
 
+    @device_synchronized
     def _writeCommand(self,
                       packet: Union[AnyStr, bytearray]) -> int:
         """
@@ -2875,9 +2875,8 @@ class FileCommandInterface(CommandInterface):
         :param packet: An encoded EBMLCommand element.
         :return: The number of bytes written.
         """
-        with self.device._busy:
-            with open(self.device.commandFile, 'wb') as f:
-                f.write(packet)
+        with open(self.device.commandFile, 'wb') as f:
+            f.write(packet)
 
         return len(packet)
 
@@ -2907,12 +2906,14 @@ class FileCommandInterface(CommandInterface):
 
 
     @property
+    @device_synchronized
     def available(self) -> bool:
         """ Is the command interface available and able to accept commands? """
         return (self.device.available
                 and os.path.isfile(self.device.commandFile))
 
 
+    @device_synchronized
     def _readResponse(self,
                       timeout: Optional[Union[int, float]] = None,
                       callback: Optional[Callable] = None) -> Union[dict, None]:
@@ -2928,28 +2929,28 @@ class FileCommandInterface(CommandInterface):
         :return: A `dict` of response data, or `None` if `callback` caused
             the process to cancel.
         """
-        with self.device._busy:
-            responseFile = os.path.join(self.device.path, self.device._RESPONSE_FILE)
-            if not os.path.isfile(responseFile):
-                return None
+        responseFile = os.path.join(self.device.path, self.device._RESPONSE_FILE)
+        if not os.path.isfile(responseFile):
+            return None
 
-            try:
-                raw = os_specific.readUncachedFile(responseFile)
-                data = self._decode(raw)
+        try:
+            raw = os_specific.readUncachedFile(responseFile)
+            data = self._decode(raw)
 
-                if 'EBMLResponse' not in data:
-                    logger.warning('Response did not contain an EBMLResponse element')
+            if 'EBMLResponse' not in data:
+                logger.warning('Response did not contain an EBMLResponse element')
 
-                return data.get('EBMLResponse', data)
+            return data.get('EBMLResponse', data)
 
-            except (AttributeError, IndexError, KeyError, TypeError) as err:
-                # TODO: Better exception handling in readResponse()
-                warnings.warn("Ignoring exception in {}._readResponse(): {!r}"
-                              .format(type(self).__name__, err))
+        except (AttributeError, IndexError, KeyError, TypeError) as err:
+            # TODO: Better exception handling in readResponse()
+            warnings.warn("Ignoring exception in {}._readResponse(): {!r}"
+                          .format(type(self).__name__, err))
 
         return None
 
 
+    @device_synchronized
     def _getTime(self,
                  pause=False,
                  timeout: Union[int, float] = 3) -> Tuple[Epoch, Epoch]:
@@ -2967,18 +2968,18 @@ class FileCommandInterface(CommandInterface):
         :return: The system time and the device time. Both are epoch
             (UNIX) time (seconds since 1970-01-01T00:00:00).
         """
-        with self.device._busy:
-            if pause:
-                t = int(time())
-                while int(time()) == t:
-                    pass
-            sysTime, devTime = os_specific.readRecorderClock(self.device.clockFile,
-                                                             timeout=timeout)
-            devTime = self._TIME_PARSER.unpack_from(devTime)[0]
+        if pause:
+            t = int(time())
+            while int(time()) == t:
+                pass
+        sysTime, devTime = os_specific.readRecorderClock(self.device.clockFile,
+                                                         timeout=timeout)
+        devTime = self._TIME_PARSER.unpack_from(devTime)[0]
 
         return sysTime, devTime
 
 
+    @device_synchronized
     def _setTime(self,
                  t: Optional[int] = None,
                  pause: bool = True,
@@ -3021,6 +3022,7 @@ class FileCommandInterface(CommandInterface):
         return t0, t
 
 
+    @device_synchronized
     def _sendCommand(self,
                      cmd: dict,
                      response: bool = True,
@@ -3056,53 +3058,53 @@ class FileCommandInterface(CommandInterface):
         now = time()
         timeout = -1 if timeout is None else timeout
         deadline = now + timeout
+        queueDepth = '?'
 
-        with self.device._busy:
-            self.lastCommand = (now, deepcopy(cmd))
+        self.lastCommand = (now, deepcopy(cmd))
 
-            # Wait until the command queue is empty.
-            # The file interface does this first.
-            while True:  # a `while True` infinite loop
-                data = self._readResponse()
-                if data:
-                    idx = data.get('ResponseIdx')
-                    queueDepth = data.get('CMDQueueDepth', 1)
-                    if queueDepth > 0:
-                        break
-                else:
-                    sleep(interval)
-
-                if timeout >= 0 and time() > deadline:
-                    if not response:
-                        logger.debug('Ignoring timeout waiting for CMDQueue '
-                                     'to empty because no response required')
-                        return None
-
-                    raise DeviceTimeout("Timed out waiting for device to complete "
-                                        "queued commands (%s remaining)" % queueDepth)
-
-                if callback is not None and callback():
-                    return None
-
-            self._writeCommand(ebml)
-
-            while timeout < 0 or time() <= deadline:
-                data = self._readResponse()
-
-                if data and data.get("ResponseIdx") != idx:
-                    return data
-
-                if callback is not None and callback():
-                    return None
-
+        # Wait until the command queue is empty.
+        # The file interface does this first.
+        while True:  # a `while True` infinite loop
+            data = self._readResponse()
+            if data:
+                idx = data.get('ResponseIdx')
+                queueDepth = data.get('CMDQueueDepth', 1)
+                if queueDepth > 0:
+                    break
+            else:
                 sleep(interval)
 
-            if not response:
-                logger.debug('Ignoring timeout waiting for response '
-                             'because no response required')
+            if timeout >= 0 and time() > deadline:
+                if not response:
+                    logger.debug('Ignoring timeout waiting for CMDQueue '
+                                 'to empty because no response required')
+                    return None
+
+                raise DeviceTimeout("Timed out waiting for device to complete "
+                                    "queued commands (%s remaining)" % queueDepth)
+
+            if callback is not None and callback():
                 return None
 
-            raise DeviceTimeout("Timed out waiting for command response (%s seconds)" % timeout)
+        self._writeCommand(ebml)
+
+        while timeout < 0 or time() <= deadline:
+            data = self._readResponse()
+
+            if data and data.get("ResponseIdx") != idx:
+                return data
+
+            if callback is not None and callback():
+                return None
+
+            sleep(interval)
+
+        if not response:
+            logger.debug('Ignoring timeout waiting for response '
+                         'because no response required')
+            return None
+
+        raise DeviceTimeout("Timed out waiting for command response (%s seconds)" % timeout)
 
 
     # =======================================================================

--- a/endaq/device/config.py
+++ b/endaq/device/config.py
@@ -27,6 +27,7 @@ from .types import Epoch
 from . import legacy
 from . import ui_defaults
 from . import util
+from .util import device_synchronized
 
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
@@ -1350,18 +1351,21 @@ class FileConfigInterface(ConfigInterface):
     # objects.
     # =======================================================================
 
+    @device_synchronized
     def _writeConfig(self, data: bytes) -> int:
         """ Open and write to the device's config file. """
         with open(self.device.configFile, 'wb') as f:
             return f.write(data)
 
 
+    @device_synchronized
     def _readConfig(self) -> bytes:
         """ Open and read the device's config file. """
         with open(self.device.configFile, 'rb') as f:
             return f.read()
 
 
+    @device_synchronized
     def _readUi(self):
         """ Open and read the device's `CONFIG.UI` file. """
         with open(self.device.configUIFile, 'rb') as f:
@@ -1374,11 +1378,13 @@ class FileConfigInterface(ConfigInterface):
         return os.path.isfile(filename)
 
 
+    @device_synchronized
     def _backupConfig(self) -> bool:
         """ Create a backup copy of the device's config file. """
         return util.makeBackup(self.device.configFile)
 
 
+    @device_synchronized
     def _restoreConfig(self,
                        remove: bool = False) -> bool:
         """ Restore a backup copy of the device's config file. """
@@ -1468,6 +1474,7 @@ class FileConfigInterface(ConfigInterface):
         return legacy.generateLegacyConfig(vals, self.device)
 
 
+    @device_synchronized
     def getConfigUI(self) -> Union[Document, MasterElement]:
         """ Load the device's ``ConfigUI`` data.
         """
@@ -1484,6 +1491,7 @@ class FileConfigInterface(ConfigInterface):
         return self.configUi
 
 
+    @device_synchronized
     def getConfig(self) -> Union[None, Document, MasterElement]:
         """ Low-level method that retrieves the device's config EBML (e.g.,
             the contents of a real device's `config.cfg` file), if any.
@@ -1505,6 +1513,7 @@ class FileConfigInterface(ConfigInterface):
         return None
 
 
+    @device_synchronized
     def loadConfig(self, config: Optional[MasterElement] = None):
         """ Process a device's configuration data.
 
@@ -1530,6 +1539,7 @@ class FileConfigInterface(ConfigInterface):
         self.configVersionRead = versionRead
 
 
+    @device_synchronized
     def applyConfig(self,
                     unknown: bool = True,
                     clear: bool = True,

--- a/endaq/device/mqtt/manager.py
+++ b/endaq/device/mqtt/manager.py
@@ -30,11 +30,10 @@ import logging
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
-from ..client import dump, synchronized
 from ..response_codes import DeviceStatusCode, CommandResponseCode
 from ..command_interfaces import CommandInterface
 from ..exceptions import CommandError, CRCError, DeviceError, ValidationError
-from ..util import getMyIP, makeClientID
+from ..util import getMyIP, makeClientID, synchronized
 from .mqtt_interface import MQTT_BROKER, MQTT_PORT
 from .advertising import Advertiser
 from .discovery import DEFAULT_NAME

--- a/endaq/device/mqtt/mqtt_client.py
+++ b/endaq/device/mqtt/mqtt_client.py
@@ -8,9 +8,10 @@ from time import sleep, time
 from typing import Any, ByteString, Dict, Optional, Tuple, Union
 
 import ebmlite
-from ..client import CommandClient, synchronized
+from ..client import CommandClient
 from ..hdlc import HDLC_BREAK_CHAR
 from ..response_codes import DeviceStatusCode
+from ..util import synchronized
 from .mqtt_interface import COMMAND_TOPIC, RESPONSE_TOPIC, STATE_TOPIC
 
 import paho.mqtt.client

--- a/endaq/device/mqtt/mqtt_interface.py
+++ b/endaq/device/mqtt/mqtt_interface.py
@@ -35,14 +35,13 @@ from .. import (_module_busy, RECORDER_TYPES, RECORDERS,
 
 from .discovery import findBrokers, SERVICE_TYPE
 from ..base import Recorder, NonRecorder
-from ..client import synchronized
 from ..command_interfaces import SerialCommandInterface
 from ..devinfo import MQTTDeviceInfo
 from ..exceptions import CommandError, CommunicationError, DeviceError
 from ..response_codes import DeviceStatusCode
 from ..simserial import SimSerialPort
 from ..types import Filename
-from .. import util
+from ..util import getMyIP, makeClientID, synchronized
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
@@ -127,7 +126,7 @@ class MQTTConnector:
             `MQTTConnector.disconnectCallback` attribute.
         """
         if not host or host in ('localhost', '127.0.0.1'):
-            host = util.getMyIP()
+            host = getMyIP()
         elif isinstance(host, (list, tuple)):
             host = host[0]
 
@@ -145,7 +144,7 @@ class MQTTConnector:
         self.disconnectCallback = disconnectCallback
 
         self.clientArgs.update(clientArgs or {})
-        self.clientArgs.setdefault('client_id', util.makeClientID(type(self).__name__))
+        self.clientArgs.setdefault('client_id', makeClientID(type(self).__name__))
         self.connectArgs.update(connectArgs or {})
 
         self.client: mqtt.Client = None

--- a/endaq/device/simserial.py
+++ b/endaq/device/simserial.py
@@ -9,7 +9,7 @@ from typing import Optional, Union
 
 from serial import PortNotOpenError
 
-from .client import synchronized
+from .util import synchronized
 
 
 class SimSerialPort:
@@ -103,4 +103,3 @@ class SimSerialPort:
     def in_waiting(self) -> int:
         """ The number of bytes currently in the buffer. """
         return len(self.buffer)
-

--- a/endaq/device/slamstick.py
+++ b/endaq/device/slamstick.py
@@ -12,6 +12,7 @@ from typing import Union
 from .base import Recorder
 from .endaq import EndaqS
 from .types import Filename
+from .util import synchronized
 
 #===============================================================================
 #
@@ -66,18 +67,18 @@ class SlamStickC(SlamStickX):
 
 
     @path.setter
+    @synchronized
     def path(self, dev: Union[Filename, None]):
         """ The recorder's filesystem path (e.g., drive letter or mount point).
         """
-        with self._busy:
-            Recorder.path.fset(self, dev)
-            if self._path:
-                if self.getInfo('McuType', '').startswith("STM32"):
-                    # HACK: New STM32-based Sx-D16 devices mostly emulate the
-                    #  earlier EFM32 series 0 SlamStick C, but update with
-                    #  the new firmware packages (i.e., `update.pkg`). This
-                    #  is a convenient place to set it.
-                    self._FW_UPDATE_FILE = Recorder._FW_UPDATE_FILE
+        Recorder.path.fset(self, dev)
+        if self._path:
+            if self.getInfo('McuType', '').startswith("STM32"):
+                # HACK: New STM32-based Sx-D16 devices mostly emulate the
+                #  earlier EFM32 series 0 SlamStick C, but update with
+                #  the new firmware packages (i.e., `update.pkg`). This
+                #  is a convenient place to set it.
+                self._FW_UPDATE_FILE = Recorder._FW_UPDATE_FILE
 
 
 # ===============================================================================

--- a/endaq/device/util.py
+++ b/endaq/device/util.py
@@ -5,10 +5,11 @@ Some basic utility functions, for internal use.
 import calendar
 import datetime
 import errno
+from functools import wraps
 import os.path
 import pathlib
 import shutil
-from threading import get_native_id
+from threading import get_native_id, RLock
 from time import sleep, time
 from typing import Any, ByteString, Callable, Dict, Optional, Tuple, Union
 import socket
@@ -225,3 +226,91 @@ def waitfor(func: Callable,
         sleep(interval)
 
     raise TimeoutError
+
+
+def synchronized(method):
+    """ Decorator for making methods use a lock, modeled after the one in
+        Java. It uses `threading.RLock`; synchronized methods called from
+        the same thread that has claimed the lock are not blocked.
+    """
+    @wraps(method)
+    def wrapped(instance, *args, **kwargs):
+        try:
+            lock = instance._synchronized_lock
+        except AttributeError:
+            lock = instance._synchronized_lock = RLock()
+        with lock:
+            return method(instance, *args, **kwargs)
+    return wrapped
+
+
+def device_synchronized(method):
+    """ A specialized version of the `synchronized` decorator for objects
+        that have a `device` attribute referring to a `Recorder` instance.
+    """
+    @wraps(method)
+    def wrapped(instance, *args, **kwargs):
+        try:
+            lock = instance.device._synchronized_lock
+        except AttributeError:
+            if not instance.device:
+                # Edge case: object's `device` not assigned (e.g., a
+                # `CommandInterface` that was explicitly instantiated)
+                # Call without lock.
+                return method(instance, *args, **kwargs)
+            else:
+                lock = instance.device._synchronized_lock = RLock()
+
+        with lock:
+            return method(instance, *args, **kwargs)
+
+    return wrapped
+
+
+def _synchronized(method):
+    """ A version of the `synchronized` decorator that does some logging,
+        for debugging use.
+    """
+    @wraps(method)
+    def wrapped(instance, *args, **kwargs):
+        try:
+            lock = instance._synchronized_lock
+        except AttributeError:
+            lock = instance._synchronized_lock = RLock()
+        with lock:
+            # Don't log the `in_waiting` property checks (too many calls)
+            if 'waiting' not in str(method):
+                logger.debug(f'>>> calling synchronized method {method} (thread {get_native_id()})')
+            try:
+                return method(instance, *args, **kwargs)
+            finally:
+                if 'waiting' not in str(method):
+                    logger.debug(f'<<< exiting synchronized method {method} (thread {get_native_id()})')
+    return wrapped
+
+
+def _device_synchronized(method):
+    """ A version of the `device_synchronized` decorator that does some logging,
+        for debugging use.
+    """
+    @wraps(method)
+    def wrapped(instance, *args, **kwargs):
+        try:
+            lock = instance.device._synchronized_lock
+        except AttributeError:
+            if hasattr(instance, 'device'):
+                lock = instance.device._synchronized_lock = RLock()
+            else:
+                # Edge case: object's `device` not assigned.
+                # Ignore, use dummy lock.
+                lock = RLock()
+        with lock:
+            # Don't log the `in_waiting` property checks (too many calls)
+            if 'waiting' not in str(method):
+                logger.debug(f'>>> calling synchronized method {method} (thread {get_native_id()})')
+            try:
+                return method(instance, *args, **kwargs)
+            finally:
+                if 'waiting' not in str(method):
+                    logger.debug(f'<<< exiting synchronized method {method} (thread {get_native_id()})')
+    return wrapped


### PR DESCRIPTION
* Standardized the use of the `synchronized` decorator in base `Recorder` class (replacing use of the `_busy` lock)
* Created `device_synchronized` decorator for methods of objects that reference a `Recorder` instance (command/config interfaces, etc.)
* Added many more lock checks to avoid race conditions in environments with many threads (e.g., the config dialog)
* Moved `synchronized` to `endaq.device.util`
* A couple of additional minor fixes