### PR TITLE
Feature/unique m dns name

### DIFF
--- a/endaq/device/mqtt/advertising.py
+++ b/endaq/device/mqtt/advertising.py
@@ -101,47 +101,59 @@ class Advertiser(Thread):
         return stopped
 
 
-    def run(self):
-        """
-        Main thread.
+    def start(self) -> None:
+        """ Start the advertising thread's activity.
+
+        It must be called at most once per thread object. It arranges for the
+        object's run() method to be invoked in a separate thread of control.
+
+        This method will raise a `RuntimeError` if called more than once on the
+        same `Advertiser` object.
         """
         logger.debug(f'Starting zeroconf advertising of {self.fullName} '
                      f'on {self.address}:{self.port}.')
-        zeroconf = Zeroconf(ip_version=self.ipVersion)
+        self.zeroconf = Zeroconf(ip_version=self.ipVersion)
 
         existing = findBrokers(None)
         basename = self.serviceName
 
+        if self.rename:
+            for n in itertools.count(1):
+                self.info = ServiceInfo(
+                        self.serviceType,
+                        self.fullName,
+                        addresses=[socket.inet_aton(self.address)],
+                        port=self.port,
+                        properties=self.properties)
+                try:
+                    # Duplicate names (apparently) allowed on different
+                    # segments of same network (e.g., ethernet adn Wi-Fi);
+                    # explicitly check for duplicates
+                    if not any(broker['name'] == self.serviceName for broker in existing):
+                        self.zeroconf.register_service(self.info)
+                        break
+                except NonUniqueNameException:
+                    continue
+
+                self.serviceName = f'{basename} {n}'
+                self.fullName = f'{self.serviceName}.{self.serviceType}'
+                logger.info(f'Name not unique, trying {self.fullName}')
+        else:
+            self.zeroconf.register_service(self.info)
+
+        super().start()
+
+
+    def run(self):
+        """
+        Main thread.
+        """
         try:
-            if self.rename:
-                for n in itertools.count(1):
-                    self.info = ServiceInfo(
-                            self.serviceType,
-                            self.fullName,
-                            addresses=[socket.inet_aton(self.address)],
-                            port=self.port,
-                            properties=self.properties)
-                    try:
-                        # Duplicate names (apparently) allowed on different
-                        # segments of same network (e.g., ethernet adn Wi-Fi);
-                        # explicitly check for duplicates
-                        if not any(broker['name'] == self.serviceName for broker in existing):
-                            zeroconf.register_service(self.info)
-                            break
-                    except NonUniqueNameException:
-                        continue
-
-                    self.serviceName = f'{basename} {n}'
-                    self.fullName = f'{self.serviceName}.{self.serviceType}'
-                    logger.info(f'Name not unique, trying {self.fullName}')
-            else:
-                zeroconf.register_service(self.info)
-
             while not self._stopEvent.is_set():
-                sleep(0.1)
+                sleep(0.25)
 
         finally:
             logger.debug(f'Ending zeroconf advertising of {self.fullName} '
                          f'on {self.address}:{self.port}.')
-            zeroconf.unregister_service(self.info)
-            zeroconf.close()
+            self.zeroconf.unregister_service(self.info)
+            self.zeroconf.close()

--- a/endaq/device/mqtt/advertising.py
+++ b/endaq/device/mqtt/advertising.py
@@ -139,6 +139,8 @@ class Advertiser(Thread):
                 self.fullName = f'{self.serviceName}.{self.serviceType}'
                 logger.info(f'Name not unique, trying {self.fullName}')
         else:
+            if any(broker['name'] == self.serviceName for broker in existing):
+                raise NonUniqueNameException
             self.zeroconf.register_service(self.info)
 
         super().start()

--- a/endaq/device/mqtt/advertising.py
+++ b/endaq/device/mqtt/advertising.py
@@ -14,7 +14,7 @@ from zeroconf import IPVersion, ServiceInfo, Zeroconf
 from zeroconf import NonUniqueNameException
 
 from .mqtt_interface import MQTT_BROKER, MQTT_PORT
-from .discovery import DEFAULT_NAME, splitServiceName
+from .discovery import DEFAULT_NAME, splitServiceName, findBrokers
 from ..util import getMyIP
 
 logger = logging.getLogger(__name__)
@@ -109,21 +109,31 @@ class Advertiser(Thread):
                      f'on {self.address}:{self.port}.')
         zeroconf = Zeroconf(ip_version=self.ipVersion)
 
+        existing = findBrokers(None)
+        basename = self.serviceName
+
         try:
             if self.rename:
                 for n in itertools.count(1):
+                    self.info = ServiceInfo(
+                            self.serviceType,
+                            self.fullName,
+                            addresses=[socket.inet_aton(self.address)],
+                            port=self.port,
+                            properties=self.properties)
                     try:
-                        zeroconf.register_service(self.info)
-                        break
+                        # Duplicate names (apparently) allowed on different
+                        # segments of same network (e.g., ethernet adn Wi-Fi);
+                        # explicitly check for duplicates
+                        if not any(broker['name'] == self.serviceName for broker in existing):
+                            zeroconf.register_service(self.info)
+                            break
                     except NonUniqueNameException:
-                        self.fullName = f'{self.serviceName} {n}.{self.serviceType}'
-                        logger.info(f'Name not unique, trying {self.fullName}')
-                        self.info = ServiceInfo(
-                                self.serviceType,
-                                self.fullName,
-                                addresses=[socket.inet_aton(self.address)],
-                                port=self.port,
-                                properties=self.properties)
+                        continue
+
+                    self.serviceName = f'{basename} {n}'
+                    self.fullName = f'{self.serviceName}.{self.serviceType}'
+                    logger.info(f'Name not unique, trying {self.fullName}')
             else:
                 zeroconf.register_service(self.info)
 

--- a/endaq/device/mqtt/manager.py
+++ b/endaq/device/mqtt/manager.py
@@ -744,6 +744,7 @@ def start(host: Optional[str] = MQTT_BROKER,
           port: int = MQTT_PORT,
           advertise: bool = True,
           name: Optional[str] = DEFAULT_NAME,
+          rename: bool = False,
           background: bool = True,
           clientArgs: Dict[str, Any] = None,
           connectArgs: Dict[str, Any] = None,
@@ -759,6 +760,8 @@ def start(host: Optional[str] = MQTT_BROKER,
     :param port: The port to which to connect.
     :param advertise: If `True`, start the mDNS advertising of the broker.
     :param name: The name under which the MQTT broker will be advertised.
+    :param rename: If `True` and the broker name is already being advertised,
+        add an incrementing number until the name is unique.
     :param background: If `True`, this function returns an
         `MQTTDeviceManager` instance with the client loop running in a
         thread. If `False`, the function will run the client loop in the
@@ -798,13 +801,13 @@ def start(host: Optional[str] = MQTT_BROKER,
         manager.cleanCache(retention=clean)
 
     if advertise:
-        kwargs = {'address': host, 'port': port, 'name': name}
+        kwargs = {'address': host, 'port': port, 'name': name, 'rename': rename}
         if advertArgs:
             kwargs.update(advertArgs)
         manager.advertiser = Advertiser(**kwargs)
-        logger.info(f'Starting advertising broker on {host}:{port} '
-                     f'as "{manager.advertiser.fullName}"')
         manager.advertiser.start()
+        logger.info(f'Advertising broker on {host}:{port} '
+                     f'as "{manager.advertiser.fullName}"')
 
     logger.info("Starting manager's MQTT client loop thread")
 
@@ -820,7 +823,7 @@ def start(host: Optional[str] = MQTT_BROKER,
     finally:
         if advertise:
             logger.debug('stopping advertiser')
-            manager.advertiser.stop()
+            manager.stop()
 
     logger.debug('exited loop')
 
@@ -860,6 +863,9 @@ if __name__ == "__main__":
                         help="Do not advertise the MQTT broker via mDNS.")
     parser.add_argument('-n', '--name', type=str, default=DEFAULT_NAME,
                         help="The advertised name of the MQTT broker.")
+    parser.add_argument('-r', '--rename', action='store_true',
+                        help="Add an incrementing number to the advertised name "
+                             "if that name is already in use.")
     parser.add_argument('-c', '--config', type=str, default=None, metavar="FILENAME",
                         help="The name of a configuration JSON file with additional "
                              "arguments for the Device Manager and advertising. "
@@ -871,7 +877,8 @@ if __name__ == "__main__":
     args = parser.parse_args()
     kwargs = {'host': args.address, 'port': args.port,
               'advertise': not args.silent, 'name': args.name,
-              'clean': args.clean, 'background': False}
+              'rename': args.rename, 'clean': args.clean,
+              'background': False}
 
     if args.config:
         with open(args.config, 'r') as f:


### PR DESCRIPTION
It was discovered that relying on the raising of a `zeroconf.NonUniqueNameException` to detect name duplication was unreliable; it does not appear to get raised if the advertising is done on different but connected networks (e.g., Ethernet and Wi-Fi).

* This PR makes the checking against existing mDNS service names explicit.
* The `rename` option is now `False` by default.
* `--rename` argument added to CLI.

