### PR TITLE
Feature/streaming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,5 @@ venv.bak/
 
 # pycharm stuff
 .idea
+
+/temp

--- a/endaq/device/__init__.py
+++ b/endaq/device/__init__.py
@@ -226,30 +226,30 @@ def getDevices(paths: Optional[List[Filename]] = None,
     """
     global RECORDERS, RECORDERS_BY_SN
 
-    with _module_busy:
-        if paths is None:
-            paths = getDeviceList(strict=strict)
-        else:
-            if isinstance(paths, (str, bytes, bytearray, Path)):
-                paths = [paths]
+    if paths is None:
+        paths = getDeviceList(strict=strict)
+    else:
+        if isinstance(paths, (str, bytes, bytearray, Path)):
+            paths = [paths]
 
-        result = set()
+    result = set()
 
-        for path in paths:
-            dev = getRecorder(path, update=update, strict=strict)
-            if dev is not None:
-                result.add(dev)
+    for path in paths:
+        dev = getRecorder(path, update=update, strict=strict)
+        if dev is not None:
+            result.add(dev)
 
-        if unmounted:
-            for dev in getSerialDevices(known=RECORDERS_BY_SN):
-                if not dev.available:
-                    dev.path = None
-                result.add(dev)
+    if unmounted:
+        for dev in getSerialDevices(known=RECORDERS_BY_SN):
+            if not dev.available:
+                dev.path = None
+            result.add(dev)
+            with _module_busy:
                 RECORDERS.pop(hash(dev), None)
                 RECORDERS[hash(dev)] = dev
                 RECORDERS_BY_SN[dev.serialInt] = dev
 
-        return sorted(result, key=lambda x: x.path or '\uffff')
+    return sorted(result, key=lambda x: x.path or '\uffff')
 
 
 def findDevice(sn: Optional[Union[str, int]] = None,
@@ -286,28 +286,27 @@ def findDevice(sn: Optional[Union[str, int]] = None,
             representing the device with the specified serial number or chip
             ID, or `None` if it cannot be found.
     """
-    with _module_busy:
-        if sn and chipId:
-            raise ValueError('Either a serial number or chip ID is required, not both')
-        elif sn is None and chipId is None:
-            raise ValueError('Either a serial number or chip ID is required')
+    if sn and chipId:
+        raise ValueError('Either a serial number or chip ID is required, not both')
+    elif sn is None and chipId is None:
+        raise ValueError('Either a serial number or chip ID is required')
 
-        if isinstance(sn, str):
-            sn = sn.lstrip(string.ascii_letters+"0")
-            if not sn:
-                sn = 0
-            sn = int(sn)
+    if isinstance(sn, str):
+        sn = sn.lstrip(string.ascii_letters+"0")
+        if not sn:
+            sn = 0
+        sn = int(sn)
 
-        if isinstance(chipId, str):
-            chipId = int(chipId, 16)
+    if isinstance(chipId, str):
+        chipId = int(chipId, 16)
 
-        for d in getDevices(paths, update=update, strict=strict, unmounted=unmounted):
-            if sn is not None and d.serialInt == sn:
-                return d
-            elif chipId is not None and d.chipId == chipId:
-                return d
+    for d in getDevices(paths, update=update, strict=strict, unmounted=unmounted):
+        if sn is not None and d.serialInt == sn:
+            return d
+        elif chipId is not None and d.chipId == chipId:
+            return d
 
-        return None
+    return None
 
 
 # ============================================================================

--- a/endaq/device/base.py
+++ b/endaq/device/base.py
@@ -236,10 +236,10 @@ class Recorder:
         """
         if self.isVirtual:
             return False
-        try:
-            return bool(self.command)
-        except UnsupportedFeature:
-            return False
+        elif self._command:
+            return True
+
+        return any(ci.hasInterface(self) for ci in command_interfaces.INTERFACES)
 
 
     @property
@@ -339,17 +339,24 @@ class Recorder:
     @synchronized
     def __repr__(self) -> str:
         """ Return repr(self). """
-        if self.isVirtual:
-            path = "virtual"
-        else:
-            # FUTURE: Show appropriate message for remote devices
-            path = self._path or "unmounted"
-
-        if self.name:
-            name = '{} "{}"'.format(self.partNumber, self.name)
-        else:
+        try:
+            path = 'virtual' if self.isVirtual else (self._path or 'unmounted')
             name = self.partNumber
-        return '<{} {} SN:{} ({})>'.format(type(self).__name__, name, self.serial, path)
+
+            try:
+                # Some debugging tools and messages can indirectly call __repr__
+                # and get stuck in a recursive loop trying to resolve `name`
+                if self.name:
+                    name = f'{self.partNumber} "{self.name}"'
+            except RecursionError:
+                logger.warning('RecursionError getting name in __repr__()!', exc_info=True)
+
+            return f'<{type(self).__name__} {name} SN:{self.serial} ({path})>'
+
+        except Exception as err:
+            # repr should never completely fail; use default object repr.
+            logger.warning(f'Error in {type(self).__name__}.__repr__(): {err!r}', exc_info=True)
+            return object.__repr__(self)
 
 
     @classmethod
@@ -1532,10 +1539,9 @@ class Recorder:
     def hasConfigInterface(self) -> bool:
         """ Can this device be configured?
         """
-        try:
-            return bool(self.config)
-        except UnsupportedFeature:
-            return False
+        if self._config:
+            return True
+        return any(ci.hasInterface(self) for ci in config.INTERFACES)
 
 
     # ===========================================================================

--- a/endaq/device/base.py
+++ b/endaq/device/base.py
@@ -163,10 +163,10 @@ class Recorder:
         # was asleep at the time). Initially set after instantiation, and
         # automatically updated by the MQTTConnector with data from the
         # Device Manager.
-        self._lastContact: int = 0
-        self._lastMeasurement: int = 0
-        self._lastHeader: int = 0
-        self._lastCommand: int = 0
+        self._lastContact: float = 0.
+        self._lastMeasurement: float = 0.
+        self._lastHeader: float = 0.
+        self._lastCommand: float = 0.
 
         # Also for remote devices: the EBML ID of the last command received,
         # updated by the MQTTConnector using data from the Device Manager.

--- a/endaq/device/client.py
+++ b/endaq/device/client.py
@@ -290,7 +290,7 @@ class CommandClient:
     # overwritten; subclasses will probably just add command methods.
     #
     # Methods should be named `command_` plus the name of the command's
-    # EBML element, (e.g., `command_sendPing()`). `GetInfo` and `SetInfo`
+    # EBML element, (e.g., `command_SendPing()`). `GetInfo` and `SetInfo`
     # have separate methods for each index, and have the index as a suffix
     # (e.g., `command_GetInfo_0`). The base `command_GetInfo()` and
     # `command_SetInfo()` probably won't need to be overridden.

--- a/endaq/device/command_interfaces.py
+++ b/endaq/device/command_interfaces.py
@@ -2504,12 +2504,17 @@ class SerialCommandInterface(CommandInterface):
                 arguments.
             :returns: `True` if the command was successful.
         """
-        return self._runSimpleCommand({'EBMLCommand': {'RecStart': {}}},
-                                      statusCode=DeviceStatusCode.START_PENDING,
-                                      timeoutMsg="Timed out waiting for recording to start",
-                                      wait=wait,
-                                      timeout=timeout,
-                                      callback=callback)
+        try:
+            return self._runSimpleCommand({'EBMLCommand': {'RecStart': {}}},
+                                          statusCode=DeviceStatusCode.START_PENDING,
+                                          timeoutMsg="Timed out waiting for recording to start",
+                                          wait=wait,
+                                          timeout=timeout,
+                                          callback=callback)
+        except CommandError as err:
+            if err.errno == DeviceStatusCode.ERR_INVALID_COMMAND and None in err.args:
+                raise CommandError(err.errno, 'Could not start recording (device already recording?)')
+            raise
 
 
     def stopRecording(self,
@@ -2531,16 +2536,22 @@ class SerialCommandInterface(CommandInterface):
         if self.device.isRemote:
             wait = False
 
-        response = self._sendCommand({'EBMLCommand': {'RecStop': {}}},
-                                     response=False,
-                                     timeout=timeout,
-                                     callback=callback)
+        try:
+            response = self._sendCommand({'EBMLCommand': {'RecStop': {}}},
+                                         response=False,
+                                         timeout=timeout,
+                                         callback=callback)
 
-        if response is not None or not wait:
+            if response is not None or not wait:
+                return True
+
+            self.awaitRemount(timeout, callback=callback)
             return True
 
-        self.awaitRemount(timeout, callback=callback)
-        return True
+        except CommandError as err:
+            if err.errno == DeviceStatusCode.ERR_INVALID_COMMAND and None in err.args:
+                raise CommandError(err.errno, 'Could not stop recording (device already stopped?)')
+            raise
 
 
     def reset(self,
@@ -3247,11 +3258,16 @@ class FileCommandInterface(CommandInterface):
 
         # FUTURE: Write commands wrapped in a <EBMLCommand> element?
         #  Exclude LegacyFileCommandInterface.
-        return self._runSimpleCommand({'RecStart': {}},
-                                      timeoutMsg="Timed out waiting for recording to start",
-                                      wait=wait,
-                                      timeout=timeout,
-                                      callback=callback)
+        try:
+            return self._runSimpleCommand({'RecStart': {}},
+                                          timeoutMsg="Timed out waiting for recording to start",
+                                          wait=wait,
+                                          timeout=timeout,
+                                          callback=callback)
+        except CommandError as err:
+            if err.errno == DeviceStatusCode.ERR_INVALID_COMMAND and None in err.args:
+                raise CommandError(err.errno, 'Could not stop recording (device already stopped?)')
+            raise
 
 
     def reset(self,

--- a/endaq/device/command_interfaces.py
+++ b/endaq/device/command_interfaces.py
@@ -7,6 +7,7 @@ from copy import deepcopy
 from datetime import datetime
 import errno
 import os.path
+from pathlib import Path
 from random import randint
 import shutil
 import string
@@ -150,14 +151,6 @@ class CommandInterface:
         """ Can the device record on command? """
         # Modern devices can record on command, assume True as default
         return self.device and not self.device.isVirtual
-
-
-    @property
-    def canStream(self) -> bool:
-        """ Can the device stream data? Only applicable to wireless devices
-            connected through an MQTT broker.
-        """
-        return False
 
 
     def resetConnection(self) -> bool:
@@ -1582,6 +1575,86 @@ class CommandInterface:
                 and whether the lock belongs to this instance.
         """
         return False, False
+
+
+    # =======================================================================
+    # Streaming. Only wireless devices on MQTT can stream.
+    # =======================================================================
+
+    @property
+    def canStream(self) -> bool:
+        """ Can the device stream data? Only applicable to wireless devices
+            connected through an MQTT broker.
+        """
+        return False
+
+
+    def startStream(self,
+                    filename: Union[str, Path],
+                    wait: bool = True,
+                    timeout: Union[int, float] = 10,
+                    callback: Optional[Callable] = None,
+                    streamCallback: Optional[Callable] = None) -> bool:
+        """ Start a device recording/streaming and save the data it sends
+            to a file.
+
+            This command is only applicable to wireless devices (i.e., the
+            enDAQ W-series) on an MQTT network running an enDAQ MQTT
+            Device Manager.
+
+            :param filename: The name of the file to which to write the
+                streamed data (e.g., an ``.IDE``).
+            :param wait: If `True`, wait for the recorer to respond and/or
+                disconnect, indicating the streaming has started.
+            :param timeout: Time (in seconds) to wait for the recorder to
+                respond. 0 will return immediately; `None` or -1 will wait
+                indefinitely.
+            :param callback: A function to call each response-checking
+                cycle. If the callback returns `True`, the wait for a
+                response will be cancelled. The callback function should
+                require no arguments. Note that this only applies while
+                starting the stream; use :meth:`stopStreaming()` to
+                stop an active stream.
+            :param streamCallback: A function to call each time a 'chunk'
+                of streamed data arrives. It should take two parameters:
+                the `Recorder` instance, and the number of bytes in the
+                chunk. Note: Unlike other callback functions, its return
+                value is ignored, so returning `False` does not cancel
+                the operation.
+            :returns: `True` if the command was successful.
+        """
+        raise UnsupportedFeature(self, self.startStream)
+
+
+    def stopStream(self,
+                   wait: bool = True,
+                   timeout: Union[int, float] = 5,
+                   callback: Optional[Callable] = None) -> bool:
+        """ Stop a device that is streaming data.
+
+            This command is only applicable to wireless devices (i.e., the
+            enDAQ W-series) on an MQTT network running an enDAQ MQTT
+            Device Manager.
+
+            :param wait: If `True`, wait for the recorer to respond
+                indicating the streaming has stopped.
+            :param timeout: Time (in seconds) to wait for the recorder to
+                respond. 0 will return immediately.
+            :param callback: A function to call each response-checking
+                cycle. If the callback returns `True`, the wait for a response
+                will be cancelled. The callback function should require no
+                arguments.
+            :returns: `True` if the command was successful.
+        """
+        raise UnsupportedFeature(self, self.stopStream)
+
+
+    def streaming(self) -> bool:
+        """ Is this instance receiving and recording data streamed from the
+            device? Note: Only applicable to wireless devices connected
+            through an MQTT broker.
+        """
+        return False
 
 
     # =======================================================================

--- a/endaq/device/command_interfaces.py
+++ b/endaq/device/command_interfaces.py
@@ -152,6 +152,14 @@ class CommandInterface:
         return self.device and not self.device.isVirtual
 
 
+    @property
+    def canStream(self) -> bool:
+        """ Can the device stream data? Only applicable to wireless devices
+            connected through an MQTT broker.
+        """
+        return False
+
+
     def resetConnection(self) -> bool:
         """
         Reset the interface. Only applicable to subclasses with a persistent
@@ -618,10 +626,13 @@ class CommandInterface:
 
 
     def stopRecording(self,
+                      wait: bool = True,
                       timeout: Union[int, float] = 5,
                       callback: Optional[Callable] = None):
         """ Stop a device that is recording, if supported.
 
+            :param wait: If `True`, wait for the recorer to respond and/or
+                remount, indicating the recording has stopped.
             :param timeout: Time (in seconds) to wait for the recorder to
                 respond. 0 will return immediately.
             :param callback: A function to call each response-checking

--- a/endaq/device/command_interfaces.py
+++ b/endaq/device/command_interfaces.py
@@ -2157,6 +2157,8 @@ class SerialCommandInterface(CommandInterface):
                     else:
                         raise
 
+                self.device._lastContact = now
+
                 if resp:
                     self._encodeResponseCodes(resp)
                     responseCode = resp.get('CommandResponseCode')

--- a/endaq/device/exceptions.py
+++ b/endaq/device/exceptions.py
@@ -7,9 +7,23 @@ __all__ = ('CommandError', 'CommunicationError', 'ConfigError',
            'DeviceTimeout', 'UnsupportedFeature',
            'ValidationError')
 
+from .response_codes import DeviceStatusCode, responsestrings
+
 
 class DeviceError(Exception):
-    """ Base class for device-related exceptions. """
+    """ Base class for device-related exceptions.
+    """
+
+    def __init__(self, *args):
+        """ Base class for device-related exceptions. """
+        # If arguments are (CommandResponseCode, CommandResponseMessage), use
+        # default message if the device's response did not include the latter.
+        if len(args) > 1 and isinstance(args[0], (int, DeviceStatusCode)):
+            if not args[1]:
+                args = args[0], responsestrings.get(args[0], ''), *args[2:]
+        super().__init__(*args)
+
+
     @property
     def errno(self):
         if len(self.args) > 1:

--- a/endaq/device/mqtt/__init__.py
+++ b/endaq/device/mqtt/__init__.py
@@ -1,2 +1,6 @@
+import logging
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
 from .mqtt_interface import *
 from . import manager

--- a/endaq/device/mqtt/manager.py
+++ b/endaq/device/mqtt/manager.py
@@ -240,6 +240,7 @@ class MQTTDevice:
                 if myId != newId:
                     logger.debug(f'Captured SetLockID command for {self.sn}: '
                                  f'{dump(newId, 0)!r}')
+                    self.manager.updateState()
 
         except KeyError as err:
             logger.debug(repr(err))

--- a/endaq/device/mqtt/manager.py
+++ b/endaq/device/mqtt/manager.py
@@ -164,9 +164,9 @@ class MQTTDevice:
             t = CommandInterface._TIME_PARSER.unpack_from(info['ClockTime'])[0]
             if abs(now - t) < MAX_DRIFT:
                 self.infoTime = t
-            else:
-                logger.debug(f'state update from {self.sn} ClockTime differs '
-                             f'from system by {now - t:.2f} (clock not set?)')
+            # else:
+            #     logger.debug(f'state update from {self.sn} ClockTime differs '
+            #                  f'from system by {now - t:.2f} (clock not set?)')
         except KeyError:
             pass
         except (struct.error, IndexError):

--- a/endaq/device/mqtt/mqtt_interface.py
+++ b/endaq/device/mqtt/mqtt_interface.py
@@ -21,10 +21,11 @@ be found using the :meth:`getDevices()` method.
 """
 
 import logging
+from pathlib import Path
 import string
 from threading import Event, Thread
 from time import sleep, time
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, BinaryIO, Callable, Dict, List, Optional, Tuple, Union
 from weakref import WeakValueDictionary
 
 import paho.mqtt.client as mqtt
@@ -152,6 +153,8 @@ class MQTTConnector:
         self._stop = Event()
         self._ports: Dict[str, "MQTTSerialPort"] = WeakValueDictionary()
         self._subscriptions = {}
+
+        self._streams: Dict[str, Recorder] = {}
 
         self.devManager = None
         self._managerStateTopic = STATE_TOPIC.format(sn='manager')
@@ -353,6 +356,8 @@ class MQTTConnector:
             self._ports[message.topic].append(message.payload)
         elif message.topic == self._managerStateTopic:
             self._onManagerState(client, userdata, message)
+        elif message.topic in self._streams:
+            self._streams[message.topic]._writeSteamChunk(message.payload)
         else:
             logger.debug(f'Message from unknown topic: {message.topic}')
 
@@ -850,6 +855,14 @@ class MQTTCommandInterface(SerialCommandInterface):
         if not device.serial:
             raise ValueError('Device must have a serial number')
         self.manager = manager
+
+        self.streamCallback: Optional[Callable] = None
+        self._streamTopic = MEASUREMENT_TOPIC.format(f'{self.device.serialInt:08d}')
+        self._stream: BinaryIO = None
+        self._streamedBytes: int = 0
+        self._lastStreamChunk: bytes = b''
+        self._lastChunkTime: float = 0
+
         super().__init__(device, make_crc=make_crc, ignore_crc=ignore_crc, **kwargs)
 
 
@@ -1155,3 +1168,151 @@ class MQTTCommandInterface(SerialCommandInterface):
             :raises UnsupportedFeature: This cannot be done via MQTT.
         """
         raise UnsupportedFeature(f'Wi-Fi cannot be configured via MQTT')
+
+
+    # =======================================================================
+    #
+    # =======================================================================
+
+    def startRecording(self,
+                       wait: bool = True,
+                       timeout: Union[int, float] = 5,
+                       callback: Optional[Callable] = None) -> bool:
+        """ Start the device recording, if supported.
+
+            :param wait: If `True`, wait for the recorer to respond
+                indicatingthe recording has started.
+            :param timeout: Time (in seconds) to wait for a response before
+                raising a `DeviceTimeout` exception. `None` or -1 will wait
+                indefinitely.
+            :param callback: A function to call each response-checking
+                cycle. If the callback returns `True`, the wait for a
+                response will be cancelled. The callback function should
+                require no arguments.
+            :returns: `True` if the command was successful.
+        """
+        # TODO: Implement `wait` actually waiting on change of status code
+        return super().startRecording(wait, timeout, callback)
+
+
+    def stopRecording(self,
+                      wait: bool = True,
+                      timeout: Union[int, float] = 5,
+                      callback: Optional[Callable] = None):
+        """ Stop a device that is recording,.
+
+            :param wait: If `True`, wait for the recorer to respond and/or
+                remount, indicating the recording has stopped.
+            :param timeout: Time (in seconds) to wait for the recorder to
+                respond. 0 will return immediately.
+            :param callback: A function to call each response-checking
+                cycle. If the callback returns `True`, the wait for a response
+                will be cancelled. The callback function should require no
+                arguments.
+            :returns: `True` if the command was successful.
+        """
+        # TODO: Implement `wait` actually waiting on change of status code
+        return super().stopRecording(wait, timeout, callback)
+
+
+    @property
+    def canStream(self) -> bool:
+        """ Is the device capable of streaming data?
+        """
+        return True
+
+
+    def startStream(self,
+                    filename: Union[str, Path],
+                    wait: bool = True,
+                    timeout: Union[int, float] = 10,
+                    callback: Optional[Callable] = None,
+                    streamCallback: Optional[Callable] = None) -> bool:
+        """
+
+            :param filename: The name of the file to which to write the
+                streamed data (e.g., an ``.IDE``).
+            :param wait: If `True`, wait for the recorer to respond and/or
+                disconnect, indicating the streaming has started.
+            :param timeout: Time (in seconds) to wait for the recorder to
+                respond. 0 will return immediately; `None` or -1 will wait
+                indefinitely.
+            :param callback: A function to call each response-checking
+                cycle. If the callback returns `True`, the wait for a
+                response will be cancelled. The callback function should
+                require no arguments. Note that this only applies while
+                starting the stream; use :meth:`stopStreaming()` to
+                stop an active stream.
+            :param streamCallback: A function to call each time a 'chunk'
+                of streamed data arrives. It should take two parameters:
+                the `Recorder` instance, and the number of bytes in the
+                chunk.
+            :returns: `True` if the command was successful.
+        """
+        if self._stream is not None and not self._stream.closed:
+            return False
+
+        self.streamCallback = streamCallback
+        self._stream = open(filename, mode='wb')
+        self._streamedBytes = 0
+        self._lastStreamChunk = b''
+        self.manager._streams[self._streamTopic] = self
+        self.manager.subscribe(self._streamTopic)
+        return self.startRecording(wait, timeout, callback)
+
+
+    def stopStream(self,
+                   wait: bool = True,
+                   timeout: Union[int, float] = 5,
+                   callback: Optional[Callable] = None) -> bool:
+        """ Stop a device that is streaming data.
+
+            :param wait: If `True`, wait for the recorer to respond
+                indicating the streaming has stopped.
+            :param timeout: Time (in seconds) to wait for the recorder to
+                respond. 0 will return immediately.
+            :param callback: A function to call each response-checking
+                cycle. If the callback returns `True`, the wait for a response
+                will be cancelled. The callback function should require no
+                arguments.
+            :returns: `True` if the command was successful.
+        """
+        if self._stream is None or self._stream.closed:
+            return False
+
+        self.manager._streams.pop(self._streamTopic)
+        self.manager.unsubscribe(self._streamTopic)
+        self.streamCallback = None
+        self._stream.close()
+
+        return self.stopRecording(wait, timeout, callback)
+
+
+    def streaming(self) -> bool:
+        """ Is this instance recording data streamed from the device?
+        """
+        # TODO: Check DeviceStatusCode as well?
+        return (self._streamTopic in self.manager._streams
+                and self._stream and not self._stream.closed)
+
+
+    def _writeStreamChunk(self, chunk: bytearray) -> int:
+        """ Write a chunk of streamed measurement data to file. Called by
+            the `MQTTConnector`.
+
+            :param chunk: The payload of a ``measurement`` topic message.
+            :returns: The number of bytes written.
+        """
+        numbytes = 0
+        if self._stream is None:
+            logger.error(f'{self.device} received stream chunk, but file not open!')
+        elif self._stream.closed:
+            logger.debug(f'{self.device} received stream chunk after file closed; ignoring')
+        else:
+            numbytes = self._stream.write(chunk)
+            self._streamedBytes += numbytes
+            self._lastStreamChunk = chunk
+            self._lastChunkTime = time()
+            if self.streamCallback:
+                self.streamCallback(self.device, numbytes)
+        return numbytes

--- a/endaq/device/mqtt/mqtt_interface.py
+++ b/endaq/device/mqtt/mqtt_interface.py
@@ -858,6 +858,7 @@ class MQTTCommandInterface(SerialCommandInterface):
 
         self.streamCallback: Optional[Callable] = None
         self._stream: BinaryIO = None
+        self._streamStartTime: float = 0
         self._streamedBytes: int = 0
         self._lastStreamChunk: bytes = b''
         self._lastChunkTime: float = 0
@@ -1260,6 +1261,7 @@ class MQTTCommandInterface(SerialCommandInterface):
 
         self.streamCallback = streamCallback
         self._stream = open(filename, mode='wb')
+        self._streamStartTime = 0
         self._streamedBytes = 0
         self._lastStreamChunk = b''
         self.manager._streams[self._streamTopic] = self
@@ -1325,6 +1327,8 @@ class MQTTCommandInterface(SerialCommandInterface):
             self._streamedBytes += numbytes
             self._lastStreamChunk = chunk
             self._lastChunkTime = time()
+            if self._streamStartTime == 0:
+                self._streamStartTime = self._lastChunkTime
             if self.streamCallback:
                 self.streamCallback(self.device, numbytes)
         return numbytes

--- a/endaq/device/mqtt/mqtt_interface.py
+++ b/endaq/device/mqtt/mqtt_interface.py
@@ -154,7 +154,7 @@ class MQTTConnector:
         self._ports: Dict[str, "MQTTSerialPort"] = WeakValueDictionary()
         self._subscriptions = {}
 
-        self._streams: Dict[str, "MQTTCommandInterface"] = {}
+        self._streamers: Dict[str, "MQTTCommandInterface"] = {}
 
         self.devManager = None
         self._managerStateTopic = STATE_TOPIC.format(sn='manager')
@@ -356,8 +356,8 @@ class MQTTConnector:
             self._ports[message.topic].append(message.payload)
         elif message.topic == self._managerStateTopic:
             self._onManagerState(client, userdata, message)
-        elif message.topic in self._streams:
-            self._streams[message.topic]._writeStreamChunk(message.payload)
+        elif message.topic in self._streamers:
+            self._streamers[message.topic]._writeStreamChunk(message.payload)
         else:
             logger.debug(f'Message from unknown topic: {message.topic}')
 
@@ -453,7 +453,7 @@ class MQTTConnector:
 
 
     @synchronized
-    def _getDevManager(self, timeout=5):
+    def _getDevManager(self):
         """ Get or create a special `Recorder` instance representing the
             connection to the MQTT Device Manager.
         """
@@ -1218,7 +1218,7 @@ class MQTTCommandInterface(SerialCommandInterface):
         # TODO: Wait until the `ExitCond` Attribute element is received?
         #  (and/or a timeout after the last packet received, and/or a change
         #  in DeviceStatusCode)
-        self.manager._streams.pop(self._streamTopic, None)
+        self.manager._streamers.pop(self._streamTopic, None)
         self.manager.unsubscribe(self._streamTopic)
 
         try:
@@ -1278,7 +1278,7 @@ class MQTTCommandInterface(SerialCommandInterface):
         self._streamStartTime = 0
         self._streamedBytes = 0
         self._lastStreamChunk = b''
-        self.manager._streams[self._streamTopic] = self
+        self.manager._streamers[self._streamTopic] = self
         self.manager.subscribe(self._streamTopic)
         return self.startRecording(wait, timeout, callback)
 
@@ -1305,8 +1305,8 @@ class MQTTCommandInterface(SerialCommandInterface):
     def streaming(self) -> bool:
         """ Is this instance receiving and recording data streamed from the device?
         """
-        # TODO: Check DeviceStatusCode for STREAMING or RECORDING as well?
-        return (self._streamTopic in self.manager._streams
+        return (self.status[1] == DeviceStatusCode.STREAMING
+                and self._streamTopic in self.manager._streamers
                 and self._stream and not self._stream.closed)
 
 

--- a/endaq/device/mqtt/mqtt_interface.py
+++ b/endaq/device/mqtt/mqtt_interface.py
@@ -568,31 +568,31 @@ class MQTTConnector:
                 response will be cancelled. The callback function
                 requires no arguments.
         """
-        with _module_busy:
-            devices = []
+        devices = []
 
-            items = self.getDeviceInfo(timeout, managerTimeout, callback)
+        items = self.getDeviceInfo(timeout, managerTimeout, callback)
 
-            for n, listItem in enumerate(items):
-                sn = 'missing!'
-                try:
-                    sn = listItem['SerialNumber']
-                    if sn in self.exclude:
-                        continue
-
-                    infoIdx = listItem['GetInfoResponse']['InfoIndex']
-                    info = bytes(listItem['GetInfoResponse']['InfoPayload'])
-
-                    if infoIdx != 0:
-                        logger.error(f'DeviceListItem {n} (SN {sn}) from Manager '
-                                     f'had wrong InfoIndex {infoIdx!r}, continuing')
-                        continue
-
-                except KeyError as err:
-                    logger.error(f'DeviceListItem {n} (SN {sn}) from Manager '
-                                 f'did not contain {err.args[0]!r}, continuing')
+        for n, listItem in enumerate(items):
+            sn = 'missing!'
+            try:
+                sn = listItem['SerialNumber']
+                if sn in self.exclude:
                     continue
 
+                infoIdx = listItem['GetInfoResponse']['InfoIndex']
+                info = bytes(listItem['GetInfoResponse']['InfoPayload'])
+
+                if infoIdx != 0:
+                    logger.error(f'DeviceListItem {n} (SN {sn}) from Manager '
+                                 f'had wrong InfoIndex {infoIdx!r}, continuing')
+                    continue
+
+            except KeyError as err:
+                logger.error(f'DeviceListItem {n} (SN {sn}) from Manager '
+                             f'did not contain {err.args[0]!r}, continuing')
+                continue
+
+            with _module_busy:
                 device = RECORDERS.get(hash(info), None)
                 systemState = listItem.get('DeviceStatusCode')
                 if systemState is None:

--- a/endaq/device/mqtt/mqtt_interface.py
+++ b/endaq/device/mqtt/mqtt_interface.py
@@ -45,7 +45,7 @@ from ..types import Filename
 from ..util import getMyIP, makeClientID, synchronized
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
+# logger.setLevel(logging.DEBUG)
 
 __all__ = ('MQTTConnector',)
 
@@ -154,7 +154,7 @@ class MQTTConnector:
         self._ports: Dict[str, "MQTTSerialPort"] = WeakValueDictionary()
         self._subscriptions = {}
 
-        self._streams: Dict[str, Recorder] = {}
+        self._streams: Dict[str, "MQTTCommandInterface"] = {}
 
         self.devManager = None
         self._managerStateTopic = STATE_TOPIC.format(sn='manager')
@@ -357,7 +357,7 @@ class MQTTConnector:
         elif message.topic == self._managerStateTopic:
             self._onManagerState(client, userdata, message)
         elif message.topic in self._streams:
-            self._streams[message.topic]._writeSteamChunk(message.payload)
+            self._streams[message.topic]._writeStreamChunk(message.payload)
         else:
             logger.debug(f'Message from unknown topic: {message.topic}')
 
@@ -857,13 +857,13 @@ class MQTTCommandInterface(SerialCommandInterface):
         self.manager = manager
 
         self.streamCallback: Optional[Callable] = None
-        self._streamTopic = MEASUREMENT_TOPIC.format(f'{self.device.serialInt:08d}')
         self._stream: BinaryIO = None
         self._streamedBytes: int = 0
         self._lastStreamChunk: bytes = b''
         self._lastChunkTime: float = 0
 
         super().__init__(device, make_crc=make_crc, ignore_crc=ignore_crc, **kwargs)
+        self._streamTopic = MEASUREMENT_TOPIC.format(sn=f'{self.device.serialInt:08d}')
 
 
     @property
@@ -1219,6 +1219,7 @@ class MQTTCommandInterface(SerialCommandInterface):
     def canStream(self) -> bool:
         """ Is the device capable of streaming data?
         """
+        # TODO: Check device config to see if the option is enabled?
         return True
 
 
@@ -1228,7 +1229,8 @@ class MQTTCommandInterface(SerialCommandInterface):
                     timeout: Union[int, float] = 10,
                     callback: Optional[Callable] = None,
                     streamCallback: Optional[Callable] = None) -> bool:
-        """
+        """ Start a device recording/streaming and save the data it sends
+            to a file.
 
             :param filename: The name of the file to which to write the
                 streamed data (e.g., an ``.IDE``).
@@ -1246,9 +1248,13 @@ class MQTTCommandInterface(SerialCommandInterface):
             :param streamCallback: A function to call each time a 'chunk'
                 of streamed data arrives. It should take two parameters:
                 the `Recorder` instance, and the number of bytes in the
-                chunk.
+                chunk. Note: Unlike other callback functions, its return
+                value is ignored, so returning `False` does not cancel
+                the operation.
             :returns: `True` if the command was successful.
         """
+        # TODO: Check device status? Or is it better to send the command
+        #  and fail if already recording/streaming?
         if self._stream is not None and not self._stream.closed:
             return False
 
@@ -1277,21 +1283,25 @@ class MQTTCommandInterface(SerialCommandInterface):
                 arguments.
             :returns: `True` if the command was successful.
         """
-        if self._stream is None or self._stream.closed:
-            return False
+        stopped = self.stopRecording(wait, timeout, callback)
 
-        self.manager._streams.pop(self._streamTopic)
+        # TODO: Wait until the `ExitCond` Attribute element is received?
+        #  (and/or a timeout after the last packet received, and/or a change
+        #  in DeviceStatusCode)
+        self.manager._streams.pop(self._streamTopic, None)
         self.manager.unsubscribe(self._streamTopic)
-        self.streamCallback = None
-        self._stream.close()
 
-        return self.stopRecording(wait, timeout, callback)
+        if self._stream and not self._stream.closed:
+            self._stream.close()
+
+        self.streamCallback = None
+        return stopped
 
 
     def streaming(self) -> bool:
-        """ Is this instance recording data streamed from the device?
+        """ Is this instance receiving and recording data streamed from the device?
         """
-        # TODO: Check DeviceStatusCode as well?
+        # TODO: Check DeviceStatusCode for STREAMING or RECORDING as well?
         return (self._streamTopic in self.manager._streams
                 and self._stream and not self._stream.closed)
 
@@ -1303,6 +1313,8 @@ class MQTTCommandInterface(SerialCommandInterface):
             :param chunk: The payload of a ``measurement`` topic message.
             :returns: The number of bytes written.
         """
+        # TODO: Automatic stream shutdown if ExitCond in the packet (and/or
+        #  DeviceStatusCode indicates not streaming)? This could get complicated.
         numbytes = 0
         if self._stream is None:
             logger.error(f'{self.device} received stream chunk, but file not open!')

--- a/endaq/device/mqtt/mqtt_interface.py
+++ b/endaq/device/mqtt/mqtt_interface.py
@@ -936,7 +936,7 @@ class MQTTCommandInterface(SerialCommandInterface):
                 If the callback returns `True`, the wait for a response will
                 be cancelled. The callback function should require no arguments.
         """
-        logger.debug(f'{self.device} Setting info index {infoIdx}')
+        logger.debug(f'{self.device.serial} Setting info index {infoIdx}')
 
         # Note: `LockID` and `CommandIdx` are explicitly added to ensure they
         #   come before the `InfoPayload` in the command dict.
@@ -989,7 +989,7 @@ class MQTTCommandInterface(SerialCommandInterface):
         """
         # Note: Reading config or user calibration requires a LockID
         # lock = index in (5, 6)
-        logger.debug(f'{self.device} Getting info index {infoIdx}')
+        logger.debug(f'{self.device.serial} Getting info index {infoIdx}')
         return super()._getInfo(infoIdx, timeout, interval, lock, index, callback)
 
 
@@ -1321,9 +1321,9 @@ class MQTTCommandInterface(SerialCommandInterface):
         #  DeviceStatusCode indicates not streaming)? This could get complicated.
         numbytes = 0
         if self._stream is None:
-            logger.error(f'{self.device} received stream chunk, but file not open!')
+            logger.error(f'{self.device.serial} received stream chunk, but file not open!')
         elif self._stream.closed:
-            logger.debug(f'{self.device} received stream chunk after file closed; ignoring')
+            logger.debug(f'{self.device.serial} received stream chunk after file closed; ignoring')
         else:
             numbytes = self._stream.write(chunk)
             self._streamedBytes += numbytes

--- a/endaq/device/mqtt/mqtt_interface.py
+++ b/endaq/device/mqtt/mqtt_interface.py
@@ -1200,7 +1200,7 @@ class MQTTCommandInterface(SerialCommandInterface):
                       wait: bool = True,
                       timeout: Union[int, float] = 5,
                       callback: Optional[Callable] = None):
-        """ Stop a device that is recording,.
+        """ Stop a device that is recording.
 
             :param wait: If `True`, wait for the recorer to respond and/or
                 remount, indicating the recording has stopped.
@@ -1213,7 +1213,21 @@ class MQTTCommandInterface(SerialCommandInterface):
             :returns: `True` if the command was successful.
         """
         # TODO: Implement `wait` actually waiting on change of status code
-        return super().stopRecording(wait, timeout, callback)
+        stopped = super().stopRecording(wait, timeout, callback)
+
+        # TODO: Wait until the `ExitCond` Attribute element is received?
+        #  (and/or a timeout after the last packet received, and/or a change
+        #  in DeviceStatusCode)
+        self.manager._streams.pop(self._streamTopic, None)
+        self.manager.unsubscribe(self._streamTopic)
+
+        try:
+            self._stream.close()
+        except AttributeError:
+            pass
+
+        self.streamCallback = None
+        return stopped
 
 
     @property
@@ -1285,19 +1299,7 @@ class MQTTCommandInterface(SerialCommandInterface):
                 arguments.
             :returns: `True` if the command was successful.
         """
-        stopped = self.stopRecording(wait, timeout, callback)
-
-        # TODO: Wait until the `ExitCond` Attribute element is received?
-        #  (and/or a timeout after the last packet received, and/or a change
-        #  in DeviceStatusCode)
-        self.manager._streams.pop(self._streamTopic, None)
-        self.manager.unsubscribe(self._streamTopic)
-
-        if self._stream and not self._stream.closed:
-            self._stream.close()
-
-        self.streamCallback = None
-        return stopped
+        return self.stopRecording(wait, timeout, callback)
 
 
     def streaming(self) -> bool:

--- a/endaq/device/response_codes.py
+++ b/endaq/device/response_codes.py
@@ -57,6 +57,25 @@ class DeviceStatusCode(IntEnum):
 CommandResponseCode = DeviceStatusCode
 
 
+responsestrings = {
+    CommandResponseCode.ERR_BUSY: "Communication channel is busy",
+    CommandResponseCode.ERR_INVALID_COMMAND: "Badly formed command",
+    CommandResponseCode.ERR_BAD_LOCK_ID: "Command Lock ID invalid",
+    CommandResponseCode.ERR_BAD_INFO_INDEX: "Unknown info index, or info is read or write only",
+    CommandResponseCode.ERR_BAD_PARAMETER: "One or more command parameters are invalid in some way",
+    CommandResponseCode.ERR_UNKNOWN_COMMAND: "Command not recognized",
+    CommandResponseCode.ERR_BAD_PAYLOAD: "Bad command payload",
+    CommandResponseCode.ERR_BAD_EBML: "Command EBML is malformed",
+    CommandResponseCode.ERR_RESPONSE_TOO_LARGE: "EBML command response too large for device",
+    CommandResponseCode.ERR_BAD_CHECKSUM: "Command checksum failed (error transmitting packet)",
+    CommandResponseCode.ERR_BAD_PACKET: "Content of command packet bad/damaged",
+    CommandResponseCode.ERR_DISCONNECTED: "The device has gone offline unexpectedly",
+    CommandResponseCode.ERR_INTERNAL_ERROR: "MQTT Device Manager internal error",
+    CommandResponseCode.ERR_UNKNOWN_DEVICE: "Device/serial number unknown to MQTT Device Manager"
+}
+""" Default message strings for `DeviceStatusCode`/`CommandResponseCode` errors """
+
+
 class WiFiConnectionStatus(IntEnum):
     """ The status of the Wi-Fi connection, returned when querying Wi-Fi.
     """


### PR DESCRIPTION
* Added basic commands for streaming
* Checking `Recorder.hasCommandInterface` no longer attempts to instantiate one
* Moved some locks around to cover only exactly what needs to be synchronous, an attempt to avoid some race conditions causing lags
* Added some default message for device-generated error responses