### PR TITLE
Added 'Last Will' packet to `MQTTDeviceManager`

### DIFF
--- a/endaq/device/mqtt/manager.py
+++ b/endaq/device/mqtt/manager.py
@@ -11,6 +11,7 @@ Starting an :class:`MQTTDeviceManager` is typically done via the
 """
 
 from collections import defaultdict
+from contextlib import suppress
 # import inspect
 from io import BytesIO
 import os.path
@@ -140,11 +141,9 @@ class MQTTDevice:
 
 
     def __del__(self):
-        try:
+        with suppress(AttributeError, TypeError, RuntimeError):
             self.manager.client.unsubscribe(self.measurementTopic)
             self.manager.client.unsubscribe(self.commandTopic)
-        except (AttributeError, TypeError, RuntimeError):
-            pass
 
 
     # =======================================================================
@@ -534,10 +533,8 @@ class MQTTDeviceManager(MQTTClient):
             raise ValueError(f'Could not get SN from topic {topic!r}')
         sn = parts[1]
 
-        try:
+        with suppress(TypeError, ValueError):
             sn = int(sn.lstrip('SWXC0'))
-        except (TypeError, ValueError):
-            pass
 
         return sn
 
@@ -795,6 +792,7 @@ def start(host: Optional[str] = MQTT_BROKER,
                 f'for broker on {host}:{port}')
     client = paho.mqtt.client.Client(paho.mqtt.client.CallbackAPIVersion.VERSION2,
                                      **clientArgs)
+    client.will_set(STATE_TOPIC.format(sn='manager'), MQTTDeviceManager.makeLWT())
     client.connect(host, port, 60, **connectArgs)
 
     # logger.info('Instantiating MQTTDeviceManager')
@@ -822,11 +820,11 @@ def start(host: Optional[str] = MQTT_BROKER,
     try:
         client.loop_forever()
     except KeyboardInterrupt as err:
-        logger.debug(f'{err!r}')
+        logger.info(f'{err!r}')
+        manager.stop()
     finally:
-        if advertise:
-            logger.debug('stopping advertiser')
-            manager.stop()
+        with suppress(AttributeError, TimeoutError):
+            manager.advertiser.stop()
 
     logger.debug('exited loop')
 

--- a/endaq/device/mqtt/mqtt_client.py
+++ b/endaq/device/mqtt/mqtt_client.py
@@ -9,7 +9,7 @@ from typing import Any, ByteString, Dict, Optional, Tuple, Union
 
 import ebmlite
 from ..client import CommandClient
-from ..hdlc import HDLC_BREAK_CHAR
+from ..hdlc import HDLC_BREAK_CHAR, hdlc_encode
 from ..response_codes import DeviceStatusCode
 from ..util import synchronized
 from .mqtt_interface import COMMAND_TOPIC, RESPONSE_TOPIC, STATE_TOPIC
@@ -286,3 +286,31 @@ class MQTTClient(CommandClient):
             self._devinfo = schema.encodes(devinfo, headers=False)
 
         return self._devinfo, None, None
+
+
+    # =======================================================================
+    #
+    # =======================================================================
+
+    @classmethod
+    def makeLWT(cls, extra: Dict[str, Any] = None) -> bytes:
+        """ Generate the contents of a minimal, generic 'Last Will and Testament'
+            packet for the client, to be sent on an unexpected MQTT client disconnection.
+            Note that the LWT must be set via `paho.mqtt.client.Client.will_set()`
+            prior to calling `paho.mqtt.client.Client.connect()`, which is done
+            before the `MQTTClient` is instantiated..
+
+            :param extra: A dictionary of optional, additional items to
+                add to the ``EBMLResponse``.
+        """
+        # NOTE: Because this needs to be called before instantiation of the
+        # MQTTClient, it does all its own encoding (as opposed to using
+        # the class' various methods). Any subclasses with special
+        # encoding needs will need to override this method.
+        resp = {'DeviceStatusCode': DeviceStatusCode.ERR_DISCONNECTED}
+        if extra:
+            resp.update(extra)
+
+        schema = ebmlite.loadSchema('command-response.xml')
+        ebml = schema.encodes({'EBMLResponse': resp})
+        return hdlc_encode(b'\x81\x00\x00' + ebml)


### PR DESCRIPTION
This adds an MQTT 'Last Will and Testament' message to the `MQTTDeviceManager`, which the broker sends in the event of abnormal disconnection (e.g., crash). The main Device Manager loop has been modified to no longer force a clean disconnection.