### PR TITLE
Feature/manager update throttle

### DIFF
--- a/endaq/device/mqtt/manager.py
+++ b/endaq/device/mqtt/manager.py
@@ -12,7 +12,6 @@ Starting an :class:`MQTTDeviceManager` is typically done via the
 
 from collections import defaultdict
 from contextlib import suppress
-# import inspect
 from io import BytesIO
 import os.path
 from pathlib import Path
@@ -505,7 +504,7 @@ class MQTTDeviceManager(MQTTClient):
         self.client.message_callback_add(self.stateSubTopic, self.onStateMessage)
 
         self.advertiser: Optional[Advertiser] =  None
-        self.stateUpdater = threading.Timer(1, lambda: None)
+        self.stateUpdater = threading.Timer(1, lambda: None)  # dummy initial value, not run
 
 
     def __repr__(self):
@@ -577,11 +576,6 @@ class MQTTDeviceManager(MQTTClient):
     def _updateState(self):
         """ Publish an updated set of data to the 'state' topic.
         """
-        # curframe = inspect.currentframe()
-        # calframe = inspect.getouterframes(curframe, 2)
-        # caller = calframe[2][3]
-        # logger.debug(f'Updating state topic {self.stateTopic} ({caller})')
-
         # Schedule the next automatic update
         self.nextUpdate = time() + self.interval
 

--- a/endaq/device/mqtt/manager.py
+++ b/endaq/device/mqtt/manager.py
@@ -17,7 +17,6 @@ from io import BytesIO
 import os.path
 from pathlib import Path
 import struct
-import sys
 import threading
 from time import time
 from typing import Any, ByteString, Dict, List, Optional, Tuple, Union
@@ -72,12 +71,6 @@ MIN_INTERVAL = 2
 # Maximum interval between scheduled MQTTDeviceManager state updates.
 # Manager updates triggered by device updates reset the interval.
 MAX_INTERVAL = 45
-
-# Paths for cached data (IDE headers, etc.)
-if sys.platform == 'win32':
-    CACHE_PATH = os.path.expandvars(r'%APPDATA%\endaq\mqtt_manager')
-else:
-    CACHE_PATH = os.path.expanduser('~/.endaq/mqtt_manager')
 
 
 # ===========================================================================

--- a/endaq/device/mqtt/manager.py
+++ b/endaq/device/mqtt/manager.py
@@ -38,7 +38,7 @@ from ..exceptions import CommandError, CRCError, DeviceError, ValidationError
 from ..util import getMyIP, makeClientID, synchronized, dump
 from .mqtt_interface import MQTT_BROKER, MQTT_PORT
 from .advertising import Advertiser
-from .caching import BaseCache, FileCache
+from .caching import CACHE_PATH, BaseCache, FileCache
 from .discovery import DEFAULT_NAME
 from .mqtt_client import MQTTClient
 from .mqtt_interface import (STATE_TOPIC, HEADER_TOPIC,
@@ -49,6 +49,7 @@ __all__ = ('MQTTDeviceManager', 'start', 'stop')
 
 # ===========================================================================
 # 'Constants'
+# Unless otherwise specified, time-related values are in seconds.
 # ===========================================================================
 
 CDB_ID = 0xA1  # EBML ID of IDE ChannelDataBlock element
@@ -66,11 +67,11 @@ MAX_DRIFT = 60 * 60
 
 # Minimum interval between MQTTDeviceManager state updates, to prevent
 # rapid device state updates from each triggering a flood of manager updates.
-MIN_INTERVAL = 30.
+MIN_INTERVAL = 2
 
 # Maximum interval between scheduled MQTTDeviceManager state updates.
 # Manager updates triggered by device updates reset the interval.
-MAX_INTERVAL = 60.
+MAX_INTERVAL = 45
 
 # Paths for cached data (IDE headers, etc.)
 if sys.platform == 'win32':
@@ -89,7 +90,8 @@ class MQTTDevice:
     presenting itself as an enDAQ recorder over MQTT. It handles capturing and
     caching metadata. Not to be confused with `endaq.device.Recorder`, which
     is a more thorough representation of the device itself, for configuration
-    and control purposes; this class is more abstract.
+    and control purposes; this class is more abstract and part of the manager's
+    internal mechanisms.
     """
 
     def __init__(self,

--- a/endaq/device/mqtt/manager.py
+++ b/endaq/device/mqtt/manager.py
@@ -18,6 +18,7 @@ import os.path
 from pathlib import Path
 import struct
 import sys
+import threading
 from time import time
 from typing import Any, ByteString, Dict, List, Optional, Tuple, Union
 from weakref import WeakSet
@@ -62,6 +63,14 @@ DEVICE_TIMEOUT = 60 * 5  # seconds
 # the device that differ from system time by this amount or more are
 # considered untrustworthy.
 MAX_DRIFT = 60 * 60
+
+# Minimum interval between MQTTDeviceManager state updates, to prevent
+# rapid device state updates from each triggering a flood of manager updates.
+MIN_INTERVAL = 30.
+
+# Maximum interval between scheduled MQTTDeviceManager state updates.
+# Manager updates triggered by device updates reset the interval.
+MAX_INTERVAL = 60.
 
 # Paths for cached data (IDE headers, etc.)
 if sys.platform == 'win32':
@@ -214,6 +223,7 @@ class MQTTDevice:
         """ Handle a command message to the device, scraping any change to
             the `LockID`.
         """
+        # TODO: Put this in a separate thread, to reduce time spent blocking message handler?
         self.lastCommand = time()
         msg = message.payload
 
@@ -256,6 +266,7 @@ class MQTTDevice:
         """ Handle an incoming chunk of IDE data. If the message completes
             an element, it is handled.
         """
+        # TODO: Put this in a separate thread, to reduce time spent blocking message handler?
         self.totalMsgs += 1
         self.lastMeasurement = self.lastContact = time()
         if self.stateInfo:
@@ -451,7 +462,8 @@ class MQTTDeviceManager(MQTTClient):
                  client: paho.mqtt.client.Client,
                  make_crc: bool = True,
                  ignore_crc: bool = False,
-                 interval: int = 45,
+                 interval: float = MAX_INTERVAL,
+                 minInterval: float = MIN_INTERVAL,
                  cache: Union[str, Path, BaseCache] = CACHE_PATH,
                  shutdown: bool = False):
         """ A client that monitors several MQTT topics, providing additional
@@ -462,8 +474,11 @@ class MQTTDeviceManager(MQTTClient):
                 and responses.
             :param ignore_crc: If `False`, do not validate incoming commands
                 or responses.
-            :param interval: The time between published `state` updates. If
-                0, no `state` updates will be published.
+            :param interval: The maximum time between scheduled `state`
+                updates, in seconds. If 0, `state` updates from the manager
+                will only be published when devices publish their states.
+            :param minInterval: The minimum time between published `state`
+                updates, in seconds.
             :param cache: The location for cached device data, either a
                 directory or an instance of a `BaseCache` storage handler.
             :param shutdown: If `True`, the manager can be shut down remotely
@@ -480,6 +495,7 @@ class MQTTDeviceManager(MQTTClient):
         else:
             self.cachePath = cache
 
+        self.minInterval = minInterval
         self.allowShutdown = shutdown
 
         self.knownDevices: dict[int, MQTTDevice] = {}
@@ -494,6 +510,7 @@ class MQTTDeviceManager(MQTTClient):
         self.client.message_callback_add(self.stateSubTopic, self.onStateMessage)
 
         self.advertiser: Optional[Advertiser] =  None
+        self.stateUpdater = threading.Timer(1, lambda: None)
 
 
     def __repr__(self):
@@ -553,6 +570,16 @@ class MQTTDeviceManager(MQTTClient):
 
     @synchronized
     def updateState(self):
+        """ Publish an updated set of data to the 'state' topic.
+        """
+        if self.stateUpdater.is_alive():
+            return
+        self.stateUpdater = threading.Timer(MIN_INTERVAL, self._updateState)
+        self.stateUpdater.daemon = True
+        self.stateUpdater.start()
+
+
+    def _updateState(self):
         """ Publish an updated set of data to the 'state' topic.
         """
         # curframe = inspect.currentframe()

--- a/endaq/device/mqtt/mqtt_client.py
+++ b/endaq/device/mqtt/mqtt_client.py
@@ -45,7 +45,7 @@ class MQTTClient(CommandClient):
                  make_crc: bool = True,
                  ignore_crc: bool = False,
                  name: str = None,
-                 interval: int = 120):
+                 interval: float = 120.0):
         """ Base class for software clients that respond like, or work with,
             enDAQ hardware.
 


### PR DESCRIPTION
This is a measure to reduce issues created by the MQTT client's message handler blocking. `MQTTDeviceManager` state messages (produced on a schedule and/or when a connected enDAQ publishes its state) are now published no more than once every 2 seconds. This is accomplished by delaying requests to publish state by 2 seconds; additional requests in that interval are ignored.

Note that the state message is created at the end of the delay, immediately before publishing, so its contents are always up to date. It isn't a queued message.