### PR TITLE
Gateway network config

### DIFF
--- a/endaq/device/base.py
+++ b/endaq/device/base.py
@@ -316,11 +316,11 @@ class Recorder:
         # devices) can be found anywhere. This will also update the paths
         # of known devices.
         if self.chipId:
-            dev = findDevice(chipId=self.chipId, update=True,
-                             unmounted=True, paths=paths, strict=strict)
+            dev: Recorder = findDevice(chipId=self.chipId, update=True,
+                                       unmounted=True, paths=paths, strict=strict)
         else:
-            dev = findDevice(sn=self.serialInt, update=True,
-                             unmounted=True, paths=paths, strict=strict)
+            dev: Recorder = findDevice(sn=self.serialInt, update=True,
+                                       unmounted=True, paths=paths, strict=strict)
 
         if dev and dev != self:
             # Device's DEVINFO has changed, change in place

--- a/endaq/device/base.py
+++ b/endaq/device/base.py
@@ -195,7 +195,7 @@ class Recorder:
 
     @property
     @synchronized
-    def command(self) -> Union[None, command_interfaces.CommandInterface]:
+    def command(self) -> command_interfaces.CommandInterface:
         """ The device's "command interface," the means through which to
             directly control the device. Only applicable to non-virtual
             recorders (i.e., actual hardware, not instantiated from a

--- a/endaq/device/client.py
+++ b/endaq/device/client.py
@@ -33,7 +33,7 @@ def requires_lock(method):
     def wrapped(instance,
                 payload: Any,
                 lockId: Optional[int] = None
-            ) -> Tuple[Union[Dict[str, Any], ByteString],
+                ) -> Tuple[Union[Dict[str, Any], ByteString],
                        Optional[DeviceStatusCode],
                        Optional[str]]:
         if lockId != instance.lockId:
@@ -53,7 +53,7 @@ def optional_lock(method):
     def wrapped(instance,
                 payload: Any,
                 lockId: Optional[int] = None
-            ) -> Tuple[Union[Dict[str, Any], ByteString],
+                ) -> Tuple[Union[Dict[str, Any], ByteString],
                        Optional[DeviceStatusCode],
                        Optional[str]]:
         if not instance.checkLock(lockId):
@@ -99,7 +99,8 @@ class CommandClient:
         if command is None:
             command = SerialCommandInterface(None, make_crc=make_crc,
                                              ignore_crc=ignore_crc)
-        self.command = command
+
+        self.command: SerialCommandInterface = command
 
         # Collect all the class' implemented command methods. See comments
         # near the end for more information.
@@ -320,10 +321,11 @@ class CommandClient:
     # =======================================================================
 
     # noinspection PyUnusedLocal
-    def command_SendPing(self,
-                         payload: Any,
-                         lockId: Optional[ByteString] = None
-            ) -> Tuple[Dict[str, Any], Optional[DeviceStatusCode], Optional[str]]:
+    def command_SendPing(
+            self,
+            payload: Dict[str, Any],
+            lockId: Optional[ByteString] = None
+    ) -> Tuple[Dict[str, Any], Optional[DeviceStatusCode], Optional[str]]:
         """ Handle a ``SendPing`` command (EBML ID 0x5700).
 
             :param payload: The command element's value.
@@ -336,10 +338,11 @@ class CommandClient:
     
 
     # noinspection PyUnusedLocal
-    def command_GetLockID(self,
-                          payload: ByteString,
-                          lockId: Optional[ByteString] = None
-            ) -> Tuple[Dict[str, Any], Optional[DeviceStatusCode], Optional[str]]:
+    def command_GetLockID(
+            self,
+            payload: Dict[str, Any],
+            lockId: Optional[ByteString] = None
+    ) -> Tuple[Dict[str, Any], Optional[DeviceStatusCode], Optional[str]]:
         """ Handle a `<GetLockID>` command (EBML ID 0x5B00).
 
             :param payload: The command element's value.
@@ -352,10 +355,11 @@ class CommandClient:
 
 
     # noinspection PyUnusedLocal
-    def command_SetLockID(self,
-                          payload: Dict[str, Any],
-                          lockId: Optional[ByteString] = None
-            ) -> Tuple[Dict[str, Any], Optional[DeviceStatusCode], Optional[str]]:
+    def command_SetLockID(
+            self,
+            payload: Dict[str, Any],
+            lockId: Optional[ByteString] = None
+    ) -> Tuple[Dict[str, Any], Optional[DeviceStatusCode], Optional[str]]:
         """ Handle a `<SetLockID>` command (EBML ID 0x5B07).
 
             :param payload: The command element's value.
@@ -376,20 +380,22 @@ class CommandClient:
 
 
     # noinspection PyUnusedLocal
-    def command_GetClock(self,
-                         payload: Dict[str, Any],
-                         lockId: Optional[ByteString] = None
-                         ) -> Tuple[Dict[str, Any], Optional[DeviceStatusCode], Optional[str]]:
+    def command_GetClock(
+            self,
+            payload: Dict[str, Any],
+            lockId: Optional[ByteString] = None
+    ) -> Tuple[Dict[str, Any], Optional[DeviceStatusCode], Optional[str]]:
         """ Handle a `<GetClock>` command (EBML ID 0x5500).
         """
         return ({'ClockTime': self.command._TIME_PARSER.pack(int(time()))},
                 None, None)
 
 
-    def command_GetInfo(self,
-                        payload: int,
-                        lockId: Optional[ByteString] = None
-            ) -> Tuple[Dict[str, Any], Optional[DeviceStatusCode], Optional[str]]:
+    def command_GetInfo(
+            self,
+            payload: Dict[str, Any],
+            lockId: Optional[ByteString] = None
+    ) -> Tuple[Dict[str, Any], Optional[DeviceStatusCode], Optional[str]]:
         """ Main handler for the `<GetInfo>` command (EBML ID 0x5B00).
         """
         try:
@@ -404,10 +410,11 @@ class CommandClient:
         return response, statusCode, statusMsg
 
 
-    def command_SetInfo(self,
-                        payload: Dict[str, Any],
-                        lockId: Optional[ByteString] = None
-            ) -> Tuple[Dict[str, Any], Optional[DeviceStatusCode], Optional[str]]:
+    def command_SetInfo(
+            self,
+            payload: Dict[str, Any],
+            lockId: Optional[ByteString] = None
+    ) -> Tuple[Dict[str, Any], Optional[DeviceStatusCode], Optional[str]]:
         """ Main handler for the `<SetInfo>` command (EBML ID 0x5B07).
         """
         try:
@@ -430,10 +437,11 @@ class CommandClient:
     # =======================================================================
 
     # noinspection PyUnusedLocal
-    def command_GetInfo_0(self,
-                          payload: ByteString,
-                          lockId: Optional[int] = None
-            ) -> Tuple[ByteString, Optional[DeviceStatusCode], Optional[str]]:
+    def command_GetInfo_0(
+            self,
+            payload: ByteString,
+            lockId: Optional[int] = None
+    ) -> Tuple[ByteString, Optional[DeviceStatusCode], Optional[str]]:
         """ Example of a `GetInfo` (0: `DEVINFO`) that does not require the
             lock be set. This should be overridden by subclasses. This
             implementation returns the same `ERR_BAD_INFO_INDEX` as is
@@ -449,10 +457,11 @@ class CommandClient:
 
     # noinspection PyUnusedLocal
     @requires_lock
-    def command_GetInfo_5(self,
-                          payload: ByteString,
-                          lockId: Optional[int] = None
-            ) -> Tuple[ByteString, Optional[DeviceStatusCode], Optional[str]]:
+    def command_GetInfo_5(
+            self,
+            payload: ByteString,
+            lockId: Optional[int] = None
+    ) -> Tuple[ByteString, Optional[DeviceStatusCode], Optional[str]]:
         """ Example of a `GetInfo` (5: `config.cfg`) that requires the lock
             be set. Note the use of the `requires_lock` decorator. This
             should be overridden in subclasses.  This implementation returns

--- a/endaq/device/command_interfaces.py
+++ b/endaq/device/command_interfaces.py
@@ -1416,11 +1416,11 @@ class CommandInterface:
             raise UnsupportedFeature('{!r} has no network adapter'.format(self.device))
 
 
-        response = self._sendCommand({'EBMLCommand': {'NetworkStatus': None}},
-                                 response=True,
-                                 timeout=timeout,
-                                 interval=interval,
-                                 callback=callback)
+        response: dict = self._sendCommand({'EBMLCommand': {'NetworkStatus': None}},
+                                           response=True,
+                                           timeout=timeout,
+                                           interval=interval,
+                                           callback=callback)
 
         return self._encodeResponseCodes(response.get('NetworkStatusResponse'))
 
@@ -1861,7 +1861,7 @@ class SerialCommandInterface(CommandInterface):
     def getSerialPort(self,
                       reset: bool = False,
                       timeout: Union[int, float] = 1,
-                      kwargs: Optional[Dict[str, Any]] = None) -> Union[None, serial.Serial]:
+                      kwargs: Optional[Dict[str, Any]] = None) -> serial.Serial:
         """
         Connect to a device's serial port.
 
@@ -2002,10 +2002,10 @@ class SerialCommandInterface(CommandInterface):
         responseCode = 0
 
         # Header: address 1 (host), EBML data, immediate write.
-        packet = bytearray([0x81, 0x00, responseCode])
-        packet.extend(ebml)
-        packet = hdlc_encode(packet, crc=self.make_crc, escaped=self.escaped)
-        return packet
+        out = bytearray([0x81, 0x00, responseCode])
+        out.extend(ebml)
+        out = hdlc_encode(out, crc=self.make_crc, escaped=self.escaped)
+        return out
 
 
     def _decode(self,
@@ -2946,12 +2946,12 @@ class SerialCommandInterface(CommandInterface):
         # Note: Reading config or user calibration requires a LockID
         # lock = index in (5, 6)
         cmd = {'EBMLCommand': {'GetInfo': infoIdx}}
-        response = self._sendCommand(cmd,
-                                     response=True,
-                                     timeout=timeout,
-                                     lock=lock,
-                                     index=index,
-                                     callback=callback)
+        response: dict = self._sendCommand(cmd,
+                                           response=True,
+                                           timeout=timeout,
+                                           lock=lock,
+                                           index=index,
+                                           callback=callback)
 
         try:
             info = response['GetInfoResponse']['InfoPayload']

--- a/endaq/device/response_codes.py
+++ b/endaq/device/response_codes.py
@@ -82,8 +82,10 @@ class WiFiConnectionStatus(IntEnum):
     IDLE = 0x00  #: Wi-Fi is inactive (and/or disconnected).
     PENDING = 0x01  #: The device is in the process of connecting to the Wi-Fi AP.
     CONNECTED = 0x02  #: The device is connected to the Wi-Fi AP.
-    AP_MODE = 0x10  #: For Gateway hardware: Gateway is in access point mode.
-    AP4G_MODE = 0x30  #: For Gateway hardware: Gateway is operating as AP and 4G bridge.
+
+    MODE_AP = 0x10  #: For Gateway hardware: Device operating as a Wi-Fi access point.
+    MODE_4G = 0x20  #: For Gateway hardware: Connected to an AP and 4G data.
+    MODE_AP4G = 0x30  #: For Gateway hardware: Gateway is operating as AP and 4G bridge.
 
 
 class CurrentWiFiStatus(IntEnum):
@@ -94,7 +96,10 @@ class CurrentWiFiStatus(IntEnum):
     CONNECTING = 1  #: The device is currently trying to connect to the Wi-Fi AP.
     CONNECTED = 2  #: The device is connected to the Wi-Fi AP, but not yet to enDAQ Cloud (or cloud connection status unknown).
     CONNECTED_CLOUD = 3  #: Connected to Wi-Fi and to enDAQ Cloud.
-    # FUTURE: AP4G/HDS
+
+    MODE_AP = 0x10  #: For Gateway hardware: Device operating as a Wi-Fi access point.
+    MODE_4G = 0x20  #: For Gateway hardware: Connected to an AP and 4G data.
+    MODE_AP4G = 0x30  #: For Gateway hardware: Gateway is operating as AP and 4G bridge.
 
 
 class WiFiConnectionError(IntEnum):

--- a/endaq/device/response_codes.py
+++ b/endaq/device/response_codes.py
@@ -97,10 +97,6 @@ class CurrentWiFiStatus(IntEnum):
     CONNECTED = 2  #: The device is connected to the Wi-Fi AP, but not yet to enDAQ Cloud (or cloud connection status unknown).
     CONNECTED_CLOUD = 3  #: Connected to Wi-Fi and to enDAQ Cloud.
 
-    MODE_AP = 0x10  #: For Gateway hardware: Device operating as a Wi-Fi access point.
-    MODE_4G = 0x20  #: For Gateway hardware: Connected to an AP and 4G data.
-    MODE_AP4G = 0x30  #: For Gateway hardware: Gateway is operating as AP and 4G bridge.
-
 
 class WiFiConnectionError(IntEnum):
     """ ESP32 error codes, potentially returned when querying Wi-Fi.

--- a/endaq/device/schemata/command-response.xml
+++ b/endaq/device/schemata/command-response.xml
@@ -76,13 +76,14 @@
                 <UnicodeElement name="Password" id="0x4202" multiple="0" mandatory="0" />
                 <UIntegerElement name="Selected" id="0x4203" multiple="0" mandatory="0" />
             </MasterElement>
-            <MasterElement name="APMode" id="0x42A0" multiple="0" mandatory="0">
+            <MasterElement name="APMode" id="0x42A0" multiple="0" mandatory="0"> For Gateway devices: Gateway running as a Wi-Fi access point
                 <UnicodeElement name="SSID" />
                 <UnicodeElement name="Password" />
-                <MasterElement name="AP4G" id="0x42A4" multiple="0" mandatory="0">
-                    <StringElement name="APN" id="0x42A5" multiple="0" mandatory="1"/>
-                    <StringElement name="SIMPin" id="0x42A6" multiple="0" mandatory="1"/>
-                </MasterElement>
+            </MasterElement>
+            <MasterElement name="MobileData" id="0x42A4" multiple="0" mandatory="0"> Gateway is connected to mobile data network (e.g., 4G)
+                <StringElement name="APN" id="0x42A5" multiple="0" mandatory="1"/>
+                <StringElement name="SIMPin" id="0x42A6" multiple="0" mandatory="1"/>
+                <StringElement name="MobileDataType" id="0x42A7" multiple="0" mandatory="0">The mobile data network type, e.g., "4G" (default)</StringElement>
             </MasterElement>
         </MasterElement>
         <MasterElement name="QueryWiFi" id="0x85" multiple="0" mandatory="0">Get a response for current Wi-Fi State</MasterElement>
@@ -148,8 +149,9 @@
                 0x00: IDLE, no connection is in process, error fields are valid.
                 0x01: PENDING, connection is in process,
                 0x02: CONNECTED, error fields will all be 0, RSSI tag is present in this data structure and represents the strength of the connected net
-                0x10: AP_MODE, the device is running as an access point. Not applicable to enDAQ data recorders.
-                0x30: AP4G_MODE, the device is running as an access point and bridge to a 4G data network. Not applicable to enDAQ data recorders.
+                0x10: MODE_AP, the device is running as an access point. Not applicable to enDAQ data recorders.
+                0x20: MODE_4G, the device is connected to a wireless data network.
+                0x30: MODE_AP4G, the device is running as an access point and bridge to a 4G data network. Not applicable to enDAQ data recorders.
             </UIntegerElement>
             <UIntegerElement name="WiFiConnectionError" id="0x5304" multiple="0" mandatory="0">Integer enum. Holds ESP32 error codes, found in https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/wifi.html#wi-fi-reason-code</UIntegerElement>
             <IntegerElement name="RSSI" id="0x5205" multiple="0" mandatory="0">Signal Strength, 0-100, where 100 is perfect. Only present if CONNECTED</IntegerElement>
@@ -159,10 +161,13 @@
             <BinaryElement name="IPV4Address" id="0x5401" multiple="0" mandatory="0"> Network IP address; absent if not connected. </BinaryElement>
             <BinaryElement name="MACAddress" id="0x5402" multiple="0" mandatory="1"> Network MAC address </BinaryElement>
             <UIntegerElement name="CurrentWiFiStatus" id="0x5403" multiple="0" mandatory="1">Integer enum.
-                0: Connection to the Wi-Fi has failed.
-                1: The device is currently trying to connect.
-                2: Connected to Wi-Fi without connection to the cloud (if cloud checking is not implemented and thus the status unknown, this should be used).
-                3: Connected to Wi-Fi with cloud connection
+                0x00: CONNECTION_FAILED, Connection to the Wi-Fi has failed.
+                0x01: CONNECTING, The device is currently trying to connect.
+                0x02: CONNECTED, Connected to Wi-Fi without connection to the cloud (if cloud checking is not implemented and thus the status unknown, this should be used).
+                0x03: CONNECTED_CLOUD, Connected to Wi-Fi with cloud connection
+                0x10: MODE_AP, the device is running as an access point. Not applicable to enDAQ data recorders.
+                0x20: MODE_4G, the device is connected to a wireless data network.
+                0x30: MODE_AP4G, the device is running as an access point and bridge to a 4G data network. Not applicable to enDAQ data recorders.
             </UIntegerElement>
         </MasterElement>
 		<BinaryElement name="ClockTime" id="0x5501" multiple="0" mandatory="0">Serial and Wireless only. 10 byte RTC clock time. Comparable to reading the CLOCK file.</BinaryElement>

--- a/endaq/device/schemata/command-response.xml
+++ b/endaq/device/schemata/command-response.xml
@@ -165,10 +165,8 @@
                 0x01: CONNECTING, The device is currently trying to connect.
                 0x02: CONNECTED, Connected to Wi-Fi without connection to the cloud (if cloud checking is not implemented and thus the status unknown, this should be used).
                 0x03: CONNECTED_CLOUD, Connected to Wi-Fi with cloud connection
-                0x10: MODE_AP, the device is running as an access point. Not applicable to enDAQ data recorders.
-                0x20: MODE_4G, the device is connected to a wireless data network.
-                0x30: MODE_AP4G, the device is running as an access point and bridge to a 4G data network. Not applicable to enDAQ data recorders.
             </UIntegerElement>
+            <StringElement name="Hostname" id="0x5404" multiple="0" mandatory="0"> For Gateway hardware: the network hostname. </StringElement>
         </MasterElement>
 		<BinaryElement name="ClockTime" id="0x5501" multiple="0" mandatory="0">Serial and Wireless only. 10 byte RTC clock time. Comparable to reading the CLOCK file.</BinaryElement>
 		<UIntegerElement name="BatteryState" id="0x5601" multiple="0" mandatory="0">Serial and Wireless only. uint16 (big endian), low byte is charge level, high byte is bit flags.


### PR DESCRIPTION
* Cleaned up AP/AP4G config commands: Added 4G/wireless data elements
* organized `WiFiConnectionStatus` codes: Now AP and 4G modes are values that can be combined bitwise with the other values.