### PR TITLE
Remove threading from Advertising object

### DIFF
--- a/endaq/device/mqtt/advertising.py
+++ b/endaq/device/mqtt/advertising.py
@@ -74,18 +74,12 @@ class Advertiser:
         self.zeroconf = None
 
 
-    def stop(self,
-             timeout: float = 10,
-             callback: Optional[Callable] = None) -> bool:
+    def stop(self) -> bool:
         """
         Stop advertising the MQTT broker.
-
-        :param timeout: Not used without threading
-        :param callback: Not used without threading
         :return: True if the advertisement was stopped.
         """
         logger.debug('Attempting to stop advertising...')
-        timeout = -1 if timeout is None else timeout
         if self.zeroconf is None:
             return True
         self.zeroconf.unregister_service(self.info)

--- a/endaq/device/mqtt/advertising.py
+++ b/endaq/device/mqtt/advertising.py
@@ -7,7 +7,6 @@ import itertools
 import json
 import logging
 import socket
-from threading import Event, Thread
 from time import time, sleep
 from typing import Any, Callable, Dict, Optional
 
@@ -23,9 +22,9 @@ from endaq.device import __version__
 logger = logging.getLogger(__name__)
 
 
-class Advertiser(Thread):
+class Advertiser:
     """
-    A thread that does mDNS service advertising of the MQTT broker.
+    A object that does mDNS service advertising of the MQTT broker.
     """
 
     def __init__(self,
@@ -37,11 +36,11 @@ class Advertiser(Thread):
                  properties: Optional[Dict[str, Any]] = None,
                  **kwargs):
         """
-        A thread that does mDNS service advertising of the MQTT broker.
+        An object to manage mDNS service advertising of the MQTT broker.
 
         :param name: The name of the service. Must be unique.
         :param address: The broker's address. Defaults to the machine running
-            the advertising thread.
+            the Advertiser.
         :param port: The broker's port number.
         :param notes: An optional description of the broker/manager; if
             provided, the notes will be included in the service advertising.
@@ -72,10 +71,7 @@ class Advertiser(Thread):
                 port=self.port,
                 properties=self.properties,
         )
-
-        self._stopEvent = Event()
-        super().__init__(daemon=True)
-        self.name = self.name.replace("Thread", type(self).__name__)
+        self.zeroconf = None
 
 
     def stop(self,
@@ -84,48 +80,31 @@ class Advertiser(Thread):
         """
         Stop advertising the MQTT broker.
 
-        :param timeout: Time to wait for the thread to shut down. 0 will
-            return immediately. `None` will wait indefinitely.
-        :param callback: A function to call repeatedly while waiting for the
-            thread to stop. If the callback returns `True`, the wait will be
-            cancelled. The callback function should require no arguments.
-        :return: Whether the thread was stopped. Note: if `timeout` is 0,
-            a false negative may occur.
+        :param timeout: Not used without threading
+        :param callback: Not used without threading
+        :return: True if the advertisement was stopped.
         """
         logger.debug('Attempting to stop advertising...')
         timeout = -1 if timeout is None else timeout
-        deadline = timeout + time()
-
-        self._stopEvent.set()
-        sleep(0.01)
-
-        while timeout != 0 and self.is_alive():
-            if timeout > 0 and time() > deadline:
-                raise TimeoutError('Timed out trying to shut down advertiser')
-            if callback and callback():
-                break
-            sleep(0.01)
-
-        stopped = not self.is_alive()
-        if stopped:
-            logger.debug('Advertiser shut down.')
-        else:
-            logger.warning('Failed to shut down advertiser within {timeout} seconds!')
-
-        return stopped
+        if self.zeroconf is None:
+            return True
+        self.zeroconf.unregister_service(self.info)
+        self.zeroconf.close()
+        self.zeroconf = None
+        return True
 
 
     def start(self) -> None:
-        """ Start the advertising thread's activity.
-
-        It must be called at most once per thread object. It arranges for the
-        object's run() method to be invoked in a separate thread of control.
+        """ Start the advertising activity.
 
         This method will raise a `RuntimeError` if called more than once on the
         same `Advertiser` object.
         """
         logger.debug(f'Starting zeroconf advertising of {self.fullName} '
                      f'on {self.address}:{self.port}.')
+        if self.zeroconf is not None:
+            raise RuntimeError('Advertising already started.')
+
         self.zeroconf = Zeroconf(ip_version=self.ipVersion)
 
         existing = findBrokers(None)
@@ -156,23 +135,6 @@ class Advertiser(Thread):
             if any(broker['name'] == self.serviceName for broker in existing):
                 raise NonUniqueNameException
             self.zeroconf.register_service(self.info)
-
-        super().start()
-
-
-    def run(self):
-        """
-        Main thread.
-        """
-        try:
-            while not self._stopEvent.is_set():
-                sleep(0.25)
-
-        finally:
-            logger.debug(f'Ending zeroconf advertising of {self.fullName} '
-                         f'on {self.address}:{self.port}.')
-            self.zeroconf.unregister_service(self.info)
-            self.zeroconf.close()
 
 
 # ===========================================================================


### PR DESCRIPTION
Verified basic functionality but it needs more testing. 
I think we talked about this a while ago, Zeroconf already runs in its own thread, so it needs to have an object kept alive but does not need us to make a thread for it.
We may want to make a singleton interface to Zeroconf so we don't need to open and close a new object every time we look for brokers, but the benefit isn't as clear there.