### PR TITLE
Feature/broker discovery

### DIFF
--- a/endaq/device/mqtt/advertising.py
+++ b/endaq/device/mqtt/advertising.py
@@ -74,18 +74,12 @@ class Advertiser:
         self.zeroconf = None
 
 
-    def stop(self,
-             timeout: float = 10,
-             callback: Optional[Callable] = None) -> bool:
+    def stop(self) -> bool:
         """
         Stop advertising the MQTT broker.
-
-        :param timeout: Not used without threading
-        :param callback: Not used without threading
         :return: True if the advertisement was stopped.
         """
         logger.debug('Attempting to stop advertising...')
-        timeout = -1 if timeout is None else timeout
         if self.zeroconf is None:
             return True
         self.zeroconf.unregister_service(self.info)

--- a/endaq/device/mqtt/advertising.py
+++ b/endaq/device/mqtt/advertising.py
@@ -38,7 +38,8 @@ class Advertiser:
         """
         An object to manage mDNS service advertising of the MQTT broker.
 
-        :param name: The name of the service. Must be unique.
+        :param name: The name of the service. Must be unique if rename is set to False.
+        :param rename: If True, try to use the name '{name} {count}' if the name is already taken
         :param address: The broker's address. Defaults to the machine running
             the Advertiser.
         :param port: The broker's port number.
@@ -103,7 +104,7 @@ class Advertiser:
 
         self.zeroconf = Zeroconf(ip_version=self.ipVersion)
 
-        existing = findBrokers(None)
+        existing = findBrokers()
         basename = self.serviceName
 
         if self.rename:
@@ -170,7 +171,7 @@ if __name__ == '__main__':
         with open(args.config, 'r') as f:
             config = json.load(f)
             kwargs.update(config)
-
+    kwargs['rename'] = False
     advertiser = Advertiser(**kwargs)
     print(f'Advertising "{advertiser.fullName}" ({advertiser.address} port {advertiser.port})')
     advertiser.start()

--- a/endaq/device/mqtt/advertising.py
+++ b/endaq/device/mqtt/advertising.py
@@ -7,7 +7,6 @@ import itertools
 import json
 import logging
 import socket
-from threading import Event, Thread
 from time import time, sleep
 from typing import Any, Callable, Dict, Optional
 
@@ -23,9 +22,9 @@ from endaq.device import __version__
 logger = logging.getLogger(__name__)
 
 
-class Advertiser(Thread):
+class Advertiser:
     """
-    A thread that does mDNS service advertising of the MQTT broker.
+    A object that does mDNS service advertising of the MQTT broker.
     """
 
     def __init__(self,
@@ -37,11 +36,11 @@ class Advertiser(Thread):
                  properties: Optional[Dict[str, Any]] = None,
                  **kwargs):
         """
-        A thread that does mDNS service advertising of the MQTT broker.
+        An object to manage mDNS service advertising of the MQTT broker.
 
         :param name: The name of the service. Must be unique.
         :param address: The broker's address. Defaults to the machine running
-            the advertising thread.
+            the Advertiser.
         :param port: The broker's port number.
         :param notes: An optional description of the broker/manager; if
             provided, the notes will be included in the service advertising.
@@ -72,10 +71,7 @@ class Advertiser(Thread):
                 port=self.port,
                 properties=self.properties,
         )
-
-        self._stopEvent = Event()
-        super().__init__(daemon=True)
-        self.name = self.name.replace("Thread", type(self).__name__)
+        self.zeroconf = None
 
 
     def stop(self,
@@ -84,48 +80,31 @@ class Advertiser(Thread):
         """
         Stop advertising the MQTT broker.
 
-        :param timeout: Time to wait for the thread to shut down. 0 will
-            return immediately. `None` will wait indefinitely.
-        :param callback: A function to call repeatedly while waiting for the
-            thread to stop. If the callback returns `True`, the wait will be
-            cancelled. The callback function should require no arguments.
-        :return: Whether the thread was stopped. Note: if `timeout` is 0,
-            a false negative may occur.
+        :param timeout: Not used without threading
+        :param callback: Not used without threading
+        :return: True if the advertisement was stopped.
         """
         logger.debug('Attempting to stop advertising...')
         timeout = -1 if timeout is None else timeout
-        deadline = timeout + time()
-
-        self._stopEvent.set()
-        sleep(0.01)
-
-        while timeout != 0 and self.is_alive():
-            if timeout > 0 and time() > deadline:
-                raise TimeoutError('Timed out trying to shut down advertiser')
-            if callback and callback():
-                break
-            sleep(0.01)
-
-        stopped = not self.is_alive()
-        if stopped:
-            logger.debug('Advertiser shut down.')
-        else:
-            logger.warning('Failed to shut down advertiser within {timeout} seconds!')
-
-        return stopped
+        if self.zeroconf is None:
+            return True
+        self.zeroconf.unregister_service(self.info)
+        self.zeroconf.close()
+        self.zeroconf = None
+        return True
 
 
     def start(self) -> None:
-        """ Start the advertising thread's activity.
-
-        It must be called at most once per thread object. It arranges for the
-        object's run() method to be invoked in a separate thread of control.
+        """ Start the advertising activity.
 
         This method will raise a `RuntimeError` if called more than once on the
         same `Advertiser` object.
         """
         logger.debug(f'Starting zeroconf advertising of {self.fullName} '
                      f'on {self.address}:{self.port}.')
+        if self.zeroconf is not None:
+            raise RuntimeError('Advertising already started.')
+
         self.zeroconf = Zeroconf(ip_version=self.ipVersion)
 
         existing = findBrokers(None)
@@ -156,23 +135,6 @@ class Advertiser(Thread):
             if any(broker['name'] == self.serviceName for broker in existing):
                 raise NonUniqueNameException
             self.zeroconf.register_service(self.info)
-
-        super().start()
-
-
-    def run(self):
-        """
-        Main thread.
-        """
-        try:
-            while not self._stopEvent.is_set():
-                sleep(0.25)
-
-        finally:
-            logger.debug(f'Ending zeroconf advertising of {self.fullName} '
-                         f'on {self.address}:{self.port}.')
-            self.zeroconf.unregister_service(self.info)
-            self.zeroconf.close()
 
 
 # ===========================================================================

--- a/endaq/device/mqtt/advertising.py
+++ b/endaq/device/mqtt/advertising.py
@@ -48,7 +48,7 @@ class Advertiser:
         :param properties: An optional dictionary of additional data to be
             included in the service advertising.
         """
-        print(f"{name=}\n{rename=}\n{address=}\n{port=}\n{notes=}\n{properties=}")
+        # print(f"{name=}\n{rename=}\n{address=}\n{port=}\n{notes=}\n{properties=}")
         if kwargs:
             logger.debug(f'Starting Advertiser, ignoring extra kwargs {kwargs}')
         self.port = port

--- a/endaq/device/mqtt/advertising.py
+++ b/endaq/device/mqtt/advertising.py
@@ -70,6 +70,8 @@ class Advertiser:
                 addresses=[socket.inet_aton(self.address)],
                 port=self.port,
                 properties=self.properties,
+                host_ttl=60,
+                other_ttl=60
         )
         self.zeroconf = None
 
@@ -111,12 +113,15 @@ class Advertiser:
                         self.fullName,
                         addresses=[socket.inet_aton(self.address)],
                         port=self.port,
-                        properties=self.properties)
+                        properties=self.properties,
+                        host_ttl=60,
+                        other_ttl=60
+                )
                 try:
                     # Duplicate names (apparently) allowed on different
                     # segments of same network (e.g., ethernet adn Wi-Fi);
                     # explicitly check for duplicates
-                    if not any(broker['name'] == self.serviceName for broker in existing):
+                    if not any(broker.name == self.serviceName for broker in existing):
                         self.zeroconf.register_service(self.info)
                         break
                 except NonUniqueNameException:
@@ -126,7 +131,7 @@ class Advertiser:
                 self.fullName = f'{self.serviceName}.{self.serviceType}'
                 logger.info(f'Name not unique, trying {self.fullName}')
         else:
-            if any(broker['name'] == self.serviceName for broker in existing):
+            if any(broker.name == self.serviceName for broker in existing):
                 raise NonUniqueNameException
             self.zeroconf.register_service(self.info)
 

--- a/endaq/device/mqtt/advertising.py
+++ b/endaq/device/mqtt/advertising.py
@@ -65,15 +65,7 @@ class Advertiser:
         self.address = address or getMyIP()
         self.ipVersion = IPVersion.V4Only
 
-        self.info = ServiceInfo(
-                self.serviceType,
-                self.fullName,
-                addresses=[socket.inet_aton(self.address)],
-                port=self.port,
-                properties=self.properties,
-                host_ttl=60,
-                other_ttl=60
-        )
+        self.info = None
         self.zeroconf = None
 
 
@@ -115,8 +107,8 @@ class Advertiser:
                         addresses=[socket.inet_aton(self.address)],
                         port=self.port,
                         properties=self.properties,
-                        host_ttl=60,
-                        other_ttl=60
+                        host_ttl=1125,                                  # NOTE: Zeroconf has a min refresh time of 1125
+                        other_ttl=1125
                 )
                 try:
                     # Duplicate names (apparently) allowed on different
@@ -134,6 +126,15 @@ class Advertiser:
         else:
             if any(broker.name == self.serviceName for broker in existing):
                 raise NonUniqueNameException
+            self.info = ServiceInfo(
+                self.serviceType,
+                self.fullName,
+                addresses=[socket.inet_aton(self.address)],
+                port=self.port,
+                properties=self.properties,
+                host_ttl=1125,  # NOTE: Zeroconf has a min refresh time of 1125
+                other_ttl=1125
+            )
             self.zeroconf.register_service(self.info)
 
 

--- a/endaq/device/mqtt/advertising.py
+++ b/endaq/device/mqtt/advertising.py
@@ -48,6 +48,7 @@ class Advertiser:
         :param properties: An optional dictionary of additional data to be
             included in the service advertising.
         """
+        print(f"{name=}\n{rename=}\n{address=}\n{port=}\n{notes=}\n{properties=}")
         if kwargs:
             logger.debug(f'Starting Advertiser, ignoring extra kwargs {kwargs}')
         self.port = port
@@ -172,7 +173,6 @@ if __name__ == '__main__':
         with open(args.config, 'r') as f:
             config = json.load(f)
             kwargs.update(config)
-    kwargs['rename'] = False
     advertiser = Advertiser(**kwargs)
     print(f'Advertising "{advertiser.fullName}" ({advertiser.address} port {advertiser.port})')
     advertiser.start()

--- a/endaq/device/mqtt/discovery.py
+++ b/endaq/device/mqtt/discovery.py
@@ -10,73 +10,55 @@ from threading import Lock
 
 from zeroconf import Zeroconf, ServiceBrowser, ServiceInfo, ServiceStateChange
 
-# from ..util import levenshtein
-
-def _on_service_state_change(zeroconf: Zeroconf,
-                             service_type: str,
-                             name: str,
-                             state_change: ServiceStateChange):
-    print(f"Called {name} ({service_type}), {state_change}")
-    if state_change == ServiceStateChange.Removed:
-        # with cls.lock:
-        #     if name in cls._mdns_list:
-        #         cls._mdns_list.remove(name)
-        return
-    info = zeroconf.get_service_info(service_type, name)
-    if not info:
-        print(f"getinfo failed for {name} ({service_type}) ")
-        return
-    # with cls.lock:
-    #     if name not in cls._mdns_list:
-    #         cls._mdns_list.append(name)
-
+from ..util import levenshtein
 
 class MDNSFinder:
+    _zc = None
+    lock = Lock()
+    _mdns_list = []
 
-    def __init__(self):
-        self._zc = None
-        self.lock = Lock()
-        self._mdns_list = []
-
-    def _on_service_state_change(self, zeroconf: Zeroconf,
+    @classmethod
+    def _on_service_state_change(cls, zeroconf: Zeroconf,
                                 service_type: str,
                                 name: str,
                                 state_change: ServiceStateChange):
         print(f"Called {name} ({service_type}), {state_change}")
         if state_change == ServiceStateChange.Removed:
-            with self.lock:
-                if name in self._mdns_list:
-                    self._mdns_list.remove(name)
+            with cls.lock:
+                if name in cls._mdns_list:
+                    cls._mdns_list.remove(name)
             return
         info = zeroconf.get_service_info(service_type, name)
         if not info:
             print(f"getinfo failed for {name} ({service_type}) ")
             return
-        with self.lock:
-            if name not in self._mdns_list:
-                self._mdns_list.append(name)
+        with cls.lock:
+            if name not in cls._mdns_list:
+                cls._mdns_list.append(name)
 
-    def start(self):
-        if self._zc is not None:
+    @classmethod
+    def start(cls):
+        if cls._zc is not None:
             return
-        self._zc = Zeroconf()
-        self.browser = ServiceBrowser(
-            self._zc,
+        cls._zc = Zeroconf()
+        cls.browser = ServiceBrowser(
+            cls._zc,
             "_endaq._tcp.local.",
-            handlers=[self._on_service_state_change],
+            handlers=[cls._on_service_state_change],
         )
 
-    # def close(self):
-    #     self._zc.close()
-    #     self._zc = None
-    #     with cls.lock:
-    #         cls._mdns_list = []
+    @classmethod
+    def close(cls):
+        cls._zc.close()
+        cls._zc = None
+        with cls.lock:
+            cls._mdns_list = []
 
-    def get_brokers(self):
-        with self.lock:
-            brokers = self._mdns_list
+    @classmethod
+    def get_brokers(cls):
+        # with cls.lock:
+        brokers = cls._mdns_list
         return brokers
-
 
 # ===========================================================================
 #
@@ -215,12 +197,37 @@ def findBrokers(*patterns,
     finally:
         zeroconf.close()
 
+from threading import Thread, active_count
+from random import randint
+
+def run_ad(name, delay, lifetime):
+    from .advertising import Advertiser
+    ad = Advertiser(name, rename=False)
+    sleep(delay)
+    ad.start()
+    sleep(lifetime)
+    ad.stop()
+
 if __name__ == '__main__':
     finder = MDNSFinder()
+    threads = []
+    for i in range(20):
+        threads.append(Thread(target=run_ad, args=(f"t{i:02}t{i:02}t{i:02}t{i:02}t{i:02}t{i:02}t{i:02}t{i:02}!!", randint(2,6), randint(4,20))))
     finder.start()
-    while True:
-        print(f"{finder.get_brokers()}")
-        sleep(2)
+    start = time()
+    print(f"Readt: {start}")
+    for t in threads:
+        t.start()
+    print(f"starting: {time()}")
+    started = False
+    while started == False or active_count() > 1:
+        if active_count() > 1:
+            started = True
+        found = finder.get_brokers()
+        if any(not s.endswith('.local.') for s in found):
+            print(f"Partial: {found}")
+
+    print(f"done: {time()}")
     # def on_service_state_change(zeroconf, service_type, name, state_change):
     #     print(state_change, name)
     #

--- a/endaq/device/mqtt/discovery.py
+++ b/endaq/device/mqtt/discovery.py
@@ -23,7 +23,7 @@ DEFAULT_NAME = "Data Collection Box Interface._endaq._tcp.local."
 DEFAULT_NAMES = ["enDAQ Remote Interface*._endaq._tcp.local.",
                  "Data Collection Box Interface*._endaq._tcp.local."]
 SERVICE_TYPE = "_endaq._tcp.local."
-mdns_finders: list["MDNSFinder"] = []
+MDNS_FINDERS: list["MDNSFinder"] = []
 
 # ===========================================================================
 #
@@ -114,7 +114,7 @@ class MDNSFinder:
         )
         self.start_time = time()
 
-    def close(self):
+    def stop(self):
         """
         Close out the search and delete all results
         """
@@ -165,7 +165,7 @@ class MDNSFinder:
         """
         if time()-self.start_time < min_lifetime:
             return
-        self.close()
+        self.stop()
         self.start()
 
 
@@ -232,7 +232,7 @@ def findBrokers(*patterns: str,
     deadline = 0
     scanDeadline = time() + scantime
     keep_open = False
-    for broker in mdns_finders:
+    for broker in MDNS_FINDERS:
         if broker.patternsMatch(patterns):
             finder = broker
             keep_open = True
@@ -240,7 +240,7 @@ def findBrokers(*patterns: str,
     if finder is None:
         finder = MDNSFinder(*patterns, timeout=timeout)
         if persistent:
-            mdns_finders.append(finder)
+            MDNS_FINDERS.append(finder)
             keep_open = True
         finder.start()
         deadline = time() + timeout
@@ -254,49 +254,5 @@ def findBrokers(*patterns: str,
         sleep(0.1)
     broker_list = finder.getBrokerList()
     if not keep_open:
-        finder.close()
+        finder.stop()
     return broker_list
-
-
-if __name__ == '__main__':
-    from threading import Thread, active_count
-    from random import randint
-
-    def run_ad(name, delay, lifetime):
-        from .advertising import Advertiser
-        ad = Advertiser(name, rename=False)
-        sleep(delay)
-        ad.start()
-        sleep(lifetime)
-        ad.stop()
-
-    finder = MDNSFinder()
-    threads = []
-    for i in range(20):
-        threads.append(Thread(target=run_ad, args=(f"t{i:02}t{i:02}t{i:02}t{i:02}t{i:02}t{i:02}t{i:02}t{i:02}!!", randint(2,6), randint(10, 30))))
-    finder.start()
-    start = time()
-    print(f"Readt: {start}")
-    for t in threads:
-        t.start()
-    print(f"starting: {time()}")
-    started = False
-    while started == False or active_count() > 1:
-        if active_count() > 1:
-            started = True
-        found = finder.getBrokerList()
-        if any(not s.name.endswith('.local.') for s in found):
-            print(f"Partial: {found}")
-
-    print(f"done: {time()}")
-    # def on_service_state_change(zeroconf, service_type, name, state_change):
-    #     print(state_change, name)
-    #
-    # zc = Zeroconf()
-    # browser = ServiceBrowser(
-    #     zc,
-    #     "_endaq._tcp.local.",
-    #     handlers=[on_service_state_change],
-    # )
-    # while True:
-    #     sleep(1)

--- a/endaq/device/mqtt/discovery.py
+++ b/endaq/device/mqtt/discovery.py
@@ -2,16 +2,20 @@
 Find an enDAQ MQTT broker.
 """
 
+import copy
+from dataclasses import dataclass
 from fnmatch import fnmatchcase
+import logging
 import re
 from time import sleep, time
 from typing import Callable, Dict, List, Optional, Tuple
-from threading import Lock
-from dataclasses import dataclass
-import copy
 
 from zeroconf import Zeroconf, ServiceBrowser, ServiceInfo, ServiceStateChange
 
+from endaq.device.util import synchronized
+
+
+logger = logging.getLogger(__name__)
 
 # ===========================================================================
 #
@@ -58,9 +62,9 @@ class MDNSFinder:
         """
         self._zc = None                         # Holder for Zeroconf object
         self.browser = None                     # Holder for serviceBrowser
-        self.lock = Lock()                      # Lock to manage access of mDNS list, which is shared between threads
-        self._mdns: Dict[str, MDNSInfo] = {}    # Dict of mDNS items indexed by full name. Don't access this without the lock!!!
-        #TODO: Clarify the intent here, it looks like patterns=None provides the default, but patterns=[None] provides all results
+        self._mdns: Dict[str, MDNSInfo] = {}    # Dict of mDNS items indexed by full name
+
+        # `*patterns` will always be a tuple w/ 0 or more items (the positional args).
         if not patterns:
             patterns = DEFAULT_NAMES[:]
         elif patterns[0] is None:
@@ -70,11 +74,13 @@ class MDNSFinder:
             patterns = list(patterns)
             for i, n in enumerate(patterns):
                 patterns[i] = '{}.{}'.format(*splitServiceName(n))
+
         self._patterns: Optional[List[str]] = patterns       # TODO: Validate Patterns
         self._timeout_ms = int(timeout * 1000)
         self.start_time = 0
 
 
+    @synchronized
     def _onServiceStateChange(self,
                               zeroconf: Zeroconf,
                               service_type: str,
@@ -85,20 +91,20 @@ class MDNSFinder:
         or updated. Do not change these parameters or names! They are
         required by Zeroconf.
         """
-        if state_change == ServiceStateChange.Removed:
-            with self.lock:
-                if name in self._mdns:
-                    del self._mdns[name]
+        if state_change == ServiceStateChange.Removed and name in self._mdns:
+            del self._mdns[name]
             return
+
         info = zeroconf.get_service_info(service_type, name, timeout=self._timeout_ms)
         if not info:
-            # TODO: Log this
-            print(f"getinfo failed for {name} ({service_type}) ")
+            logger.debug(f"getinfo failed for {name} ({service_type}) ")
             return
-        with self.lock:
-            if not self._patterns or any(fnmatchcase(info.name, p) for p in self._patterns):
-                self._mdns[info.name] = parseServiceInfo(info)
 
+        if not self._patterns or any(fnmatchcase(info.name, p) for p in self._patterns):
+            self._mdns[info.name] = parseServiceInfo(info)
+
+
+    @synchronized
     def start(self):
         """
         Start searching for the specified mDNS service types.
@@ -106,11 +112,10 @@ class MDNSFinder:
         if self._zc is not None:
             return
         self._zc = Zeroconf()
-        with self.lock:     # Locking is not really needed here, just being extra safe
-            if not self._patterns:
-                services = [SERVICE_TYPE]
-            else:
-                services = [splitServiceName(n)[1] for n in self._patterns]
+        if not self._patterns:
+            services = [SERVICE_TYPE]
+        else:
+            services = [splitServiceName(n)[1] for n in self._patterns]
         self.browser = ServiceBrowser(
             zc=self._zc,
             type_=services,
@@ -119,6 +124,7 @@ class MDNSFinder:
         self.start_time = time()
 
 
+    @synchronized
     def stop(self):
         """
         Close out the search and delete all results.
@@ -127,20 +133,19 @@ class MDNSFinder:
             self.browser.cancel()
             self._zc.close()
         self._zc = None
-        with self.lock:
-            self._mdns = {}
+        self._mdns.clear()
 
 
+    @synchronized
     def getBrokerDict(self) -> Dict[str, MDNSInfo]:
         """
         Copy the dict of brokers and get a separate list of their names
 
         :returns: A dictionary of the brokers.
         """
-        with self.lock:
-            # Removing the Levenshtein distance sorting, it looked like we were sorting here, then re-sorting in the broker select
-            brokers = copy.deepcopy(self._mdns)
-        return brokers
+        # Removing the Levenshtein distance sorting, it looked like we were sorting here,
+        # then re-sorting in the broker select
+        return copy.deepcopy(self._mdns)
 
 
     def getBrokerList(self) -> List[MDNSInfo]:
@@ -151,24 +156,28 @@ class MDNSFinder:
         return list(self.getBrokerDict().values())
 
 
+    @synchronized
     def patternsMatch(self, *patterns) -> bool:
         """
         See if the specified patterns match what this broker is using.
         """
-        with self.lock:
-            if self._patterns is None and patterns is None:
-                return True
-            my_patterns = set(self._patterns)
-        return my_patterns == set(patterns)
+        if self._patterns is None:
+            return True
+        return set(self._patterns) == set(patterns)
 
 
+    @synchronized
     def restart(self, min_lifetime: int = 5):
         """
-        Stop and restart the discovery process unless it has already been started within min_lifetime seconds
-        :param min_lifetime: Don't kill the previous process if it was started min_lifetime seconds ago
+        Stop and restart the discovery process unless it has already been
+        started within min_lifetime seconds
+
+        :param min_lifetime: Don't kill the previous process if it was
+            started min_lifetime seconds ago
         """
-        if time()-self.start_time < min_lifetime:
+        if time() - self.start_time < min_lifetime:
             return
+
         self.stop()
         self.start()
 
@@ -176,7 +185,8 @@ class MDNSFinder:
 def splitServiceName(serviceName: str) -> Tuple[str, str]:
     """
     Split a full mDNS name (including service) into the base name and the
-    service name. So 'name._endaq._tcp.local.' becomes 'name' and '_endaq._tcp.local.'
+    service name. So ``"name._endaq._tcp.local."`` becomes ``"name"`` and
+    ``"_endaq._tcp.local."``.
     """
     if m := re.match(r"(.+)\.(.+\._tcp\.local\.)", serviceName):
         return m.groups()

--- a/endaq/device/mqtt/discovery.py
+++ b/endaq/device/mqtt/discovery.py
@@ -43,7 +43,7 @@ class MDNSInfo:
     serviceType: str
     host: list[str]
     port: int
-    properties: dict[bytes, bytes | None]
+    properties: dict[bytes, Optional[bytes]]
 
 
 class MDNSFinder:
@@ -69,7 +69,7 @@ class MDNSFinder:
             patterns = list(patterns)
             for i, n in enumerate(patterns):
                 patterns[i] = '{}.{}'.format(*splitServiceName(n))
-        self._patterns: list[str] | None = patterns       # TODO: Validate Patterns
+        self._patterns: Optional[list[str]] = patterns       # TODO: Validate Patterns
         self._timeout_ms = int(timeout * 1000)
         self.start_time = 0
 
@@ -153,6 +153,8 @@ class MDNSFinder:
         See if the specified patterns match what this broker is using
         """
         with self.lock:
+            if self._patterns is None and patterns is None:
+                return True
             my_patterns = set(self._patterns)
         return my_patterns == set(patterns)
 
@@ -283,7 +285,7 @@ if __name__ == '__main__':
         if active_count() > 1:
             started = True
         found = finder.getBrokerList()
-        if any(not s.endswith('.local.') for s in found):
+        if any(not s.name.endswith('.local.') for s in found):
             print(f"Partial: {found}")
 
     print(f"done: {time()}")

--- a/endaq/device/mqtt/discovery.py
+++ b/endaq/device/mqtt/discovery.py
@@ -6,10 +6,76 @@ from fnmatch import fnmatchcase
 import re
 from time import sleep, time
 from typing import Any, Callable, Dict, List, Optional, Tuple
+from threading import Lock
 
 from zeroconf import Zeroconf, ServiceBrowser, ServiceInfo, ServiceStateChange
 
-from ..util import levenshtein
+# from ..util import levenshtein
+
+def _on_service_state_change(zeroconf: Zeroconf,
+                             service_type: str,
+                             name: str,
+                             state_change: ServiceStateChange):
+    print(f"Called {name} ({service_type}), {state_change}")
+    if state_change == ServiceStateChange.Removed:
+        # with cls.lock:
+        #     if name in cls._mdns_list:
+        #         cls._mdns_list.remove(name)
+        return
+    info = zeroconf.get_service_info(service_type, name)
+    if not info:
+        print(f"getinfo failed for {name} ({service_type}) ")
+        return
+    # with cls.lock:
+    #     if name not in cls._mdns_list:
+    #         cls._mdns_list.append(name)
+
+
+class MDNSFinder:
+
+    def __init__(self):
+        self._zc = None
+        self.lock = Lock()
+        self._mdns_list = []
+
+    def _on_service_state_change(self, zeroconf: Zeroconf,
+                                service_type: str,
+                                name: str,
+                                state_change: ServiceStateChange):
+        print(f"Called {name} ({service_type}), {state_change}")
+        if state_change == ServiceStateChange.Removed:
+            with self.lock:
+                if name in self._mdns_list:
+                    self._mdns_list.remove(name)
+            return
+        info = zeroconf.get_service_info(service_type, name)
+        if not info:
+            print(f"getinfo failed for {name} ({service_type}) ")
+            return
+        with self.lock:
+            if name not in self._mdns_list:
+                self._mdns_list.append(name)
+
+    def start(self):
+        if self._zc is not None:
+            return
+        self._zc = Zeroconf()
+        self.browser = ServiceBrowser(
+            self._zc,
+            "_endaq._tcp.local.",
+            handlers=[self._on_service_state_change],
+        )
+
+    # def close(self):
+    #     self._zc.close()
+    #     self._zc = None
+    #     with cls.lock:
+    #         cls._mdns_list = []
+
+    def get_brokers(self):
+        with self.lock:
+            brokers = self._mdns_list
+        return brokers
 
 
 # ===========================================================================
@@ -148,3 +214,21 @@ def findBrokers(*patterns,
 
     finally:
         zeroconf.close()
+
+if __name__ == '__main__':
+    finder = MDNSFinder()
+    finder.start()
+    while True:
+        print(f"{finder.get_brokers()}")
+        sleep(2)
+    # def on_service_state_change(zeroconf, service_type, name, state_change):
+    #     print(state_change, name)
+    #
+    # zc = Zeroconf()
+    # browser = ServiceBrowser(
+    #     zc,
+    #     "_endaq._tcp.local.",
+    #     handlers=[on_service_state_change],
+    # )
+    # while True:
+    #     sleep(1)

--- a/endaq/device/mqtt/discovery.py
+++ b/endaq/device/mqtt/discovery.py
@@ -148,11 +148,7 @@ class MDNSFinder:
         Copy the list of brokers
         :returns: list of the brokers:
         """
-        brokers = []
-        with self.lock:
-            for k, v in self._mdns.items():
-                brokers.append(copy.deepcopy(v))
-        return brokers
+        return list(self.getBrokerDict().values())
 
 
     def patternsMatch(self, *patterns) -> bool:

--- a/endaq/device/mqtt/discovery.py
+++ b/endaq/device/mqtt/discovery.py
@@ -8,6 +8,7 @@ from time import sleep, time
 from typing import Any, Callable, Dict, List, Optional, Tuple
 from threading import Lock
 from dataclasses import dataclass
+import copy
 
 from zeroconf import Zeroconf, ServiceBrowser, ServiceInfo, ServiceStateChange
 
@@ -30,19 +31,34 @@ mdns_finders: list["MDNSFinder"] = []
 
 @dataclass
 class MDNSInfo:
+    """
+    Dataclass for organizing info about mDNS services
+    :param name: Root name of mDNS name, so 'name._endaq._tcp.local.' becomes 'name'
+    :param serviceType: Service name of mDNS name, so 'name._endaq._tcp.local.' becomes '_endaq._tcp.local.'
+    :param host: list of IP addresses for mDNS advertiser. Generally only the first item is used
+    :param port: port number for mDNS advertiser
+    :param properties: Properties advertised by the mDNS host
+    """
     name: str
     serviceType: str
-    host: str
+    host: list[str]
     port: int
     properties: dict[bytes, bytes | None]
 
 
 class MDNSFinder:
-    def __init__(self, patterns: Optional[list[str]], timeout=5):
-        self._zc = None
-        self.browser = None
-        self.lock = Lock()
-        self._mdns_list: list[MDNSInfo] = []
+    def __init__(self, *patterns, timeout:float=5.0):
+        """
+        Object to handle searching for mDNS hosts. Most of the work is handled by Zeroconf in the background
+        :param patterns: Zero or more MQTT Broker names (multiple positional
+            arguments). Glob-like wildcards may be used (case-sensitive).
+            `None` will return all MQTT brokers.
+        :param timeout: How many seconds to wait while querying for mDNS host info before giving up
+        """
+        self._zc = None                         # Holder for Zeroconf object
+        self.browser = None                     # Holder for serviceBrowser
+        self.lock = Lock()                      # Lock to manage access of mDNS list, which is shared between threads
+        self._mdns: dict[str, MDNSInfo] = {}    # Dict of mDNS items indexed by full name. Don't access this without the lock!!!
         #TODO: Clarify the intent here, it looks like patterns=None provides the default, but patterns=[None] provides all results
         if not patterns:
             patterns = DEFAULT_NAMES[:]
@@ -54,28 +70,36 @@ class MDNSFinder:
             for i, n in enumerate(patterns):
                 patterns[i] = '{}.{}'.format(*splitServiceName(n))
         self._patterns: list[str] | None = patterns       # TODO: Validate Patterns
-        self._timeout_ms = timeout * 1000
+        self._timeout_ms = int(timeout * 1000)
+        self.start_time = 0
 
-    def _on_service_state_change(self, zeroconf: Zeroconf,
-                                service_type: str,
-                                name: str,
-                                state_change: ServiceStateChange):
+    def _onServiceStateChange(self, zeroconf: Zeroconf,
+                              service_type: str,
+                              name: str,
+                              state_change: ServiceStateChange):
+        """
+        Called by Zeroconf serviceBrowser when an mDNS is added, removed, or updated
+        Do not change these parameters or names! They are required by Zeroconf
+        """
         print(f"Called {name} ({service_type}), {state_change}")
         if state_change == ServiceStateChange.Removed:
             with self.lock:
-                if name in self._mdns_list:
-                    self._mdns_list.remove(name)
+                if name in self._mdns:
+                    del self._mdns[name]
             return
         info = zeroconf.get_service_info(service_type, name, timeout=self._timeout_ms)
         if not info:
+            # TODO: Log this
             print(f"getinfo failed for {name} ({service_type}) ")
             return
         with self.lock:
             if not self._patterns or any(fnmatchcase(info.name, p) for p in self._patterns):
-                if info.name not in self._mdns_list:
-                    self._mdns_list.append(parseServiceInfo(info))
+                self._mdns[info.name]=parseServiceInfo(info)
 
     def start(self):
+        """
+        Start searching for the specified mDNS types
+        """
         if self._zc is not None:
             return
         self._zc = Zeroconf()
@@ -88,36 +112,67 @@ class MDNSFinder:
         self.browser = ServiceBrowser(
             zc=self._zc,
             type_=services,
-            handlers=[self._on_service_state_change],
+            handlers=[self._onServiceStateChange],
         )
+        self.start_time = time()
 
     def close(self):
+        """
+        Close out the search and delete all results
+        """
         if self._zc is not None:
             self.browser.cancel()
             self._zc.close()
         self._zc = None
         with self.lock:
-            self._mdns_list = []
+            self._mdns = {}
 
-    def get_brokers(self) -> list[MDNSInfo]:
+    def getBrokerDict(self) -> tuple[dict[str, MDNSInfo], list[str]]:
+        """
+        Copy the dict of brokers and get a separate list of their names
+        :returns dict of the brokers and a sorted list of the keys:
+        """
         with self.lock:
-            if self._patterns and len(self._mdns_list) > 1:
-                # Sort by similarity to patterns
-                self._mdns_list.sort(key=lambda x: min(levenshtein(x.name, p)
-                                                   for p in self._patterns))
-            brokers = self._mdns_list[:]
+            # Removing the Levenshtein distance sorting, it looked like we were sorting here, then re-sorting in the broker select
+            brokers = copy.deepcopy(self._mdns)
+        # TODO: Consider storing names separately and keeping it sorted if we're using this function a lot
+        names = sorted(brokers.keys())
+        return brokers, names
+
+    def getBrokerList(self) -> list[MDNSInfo]:
+        """
+        Copy the list of brokers
+        :returns list of the brokers:
+        """
+        brokers = []
+        with self.lock:
+            for k, v in self._mdns.items():
+                brokers.append(copy.deepcopy(v))
         return brokers
 
-    def patterns_match(self, *patterns) -> bool:
+    def patternsMatch(self, *patterns) -> bool:
+        """
+        See if the specified patterns match what this broker is using
+        """
         with self.lock:
             my_patterns = set(self._patterns)
         return my_patterns == set(patterns)
+
+    def restart(self, min_lifetime: int=5):
+        """
+        Stop and restart the discovery process unless it has already been started within min_lifetime seconds
+        :param min_lifetime: Don't kill the previous process if it was started min_lifetime seconds ago
+        """
+        if time()-self.start_time < min_lifetime:
+            return
+        self.close()
+        self.start()
 
 
 def splitServiceName(serviceName: str) -> Tuple[str, str]:
     """
     Split a full mDNS name (including service) into the base name and the
-    service name.
+    service name. So 'name._endaq._tcp.local.' becomes 'name' and '_endaq._tcp.local.'
     """
     if m := re.match(r"(.+)\.(.+\._tcp\.local\.)", serviceName):
         return m.groups()
@@ -133,7 +188,7 @@ def parseServiceInfo(info: ServiceInfo) -> MDNSInfo:
     by the service).
     """
     name, serviceType = splitServiceName(info.name)
-    addr = info.parsed_addresses()[0]
+    addr = info.parsed_addresses()
     # Some services' properties contain null keys
     props = {k: v for k, v in info.properties.items() if k}
     return MDNSInfo(name=name, serviceType=serviceType,
@@ -157,7 +212,7 @@ def getBroker(name: str = DEFAULT_NAME,
 def findBrokers(*patterns: str,
                 scantime: float = 2,
                 timeout: float = 5,
-                callback: Optional[Callable] = None) -> List[MDNSInfo]:
+                callback: Optional[Callable] = None, persistent: bool=False) -> List[MDNSInfo]:
     """
     Find enDAQ-advertised MQTT Brokers.
 
@@ -176,23 +231,31 @@ def findBrokers(*patterns: str,
     finder = None
     deadline = 0
     scanDeadline = time() + scantime
+    keep_open = False
     for broker in mdns_finders:
-        if broker.patterns_match(patterns):
+        if broker.patternsMatch(patterns):
             finder = broker
+            keep_open = True
             break
     if finder is None:
         finder = MDNSFinder(*patterns, timeout=timeout)
-        mdns_finders.append(finder)
+        if persistent:
+            mdns_finders.append(finder)
+            keep_open = True
         finder.start()
         deadline = time() + timeout
+
 
     while time() < deadline:
         if callback and callback():
             break
-        if finder.get_brokers() and time() > scanDeadline:
+        if finder.getBrokerList() and time() > scanDeadline:
             break
         sleep(0.1)
-    return finder.get_brokers()
+    broker_list = finder.getBrokerList()
+    if not keep_open:
+        finder.close()
+    return broker_list
 
 
 if __name__ == '__main__':
@@ -210,7 +273,7 @@ if __name__ == '__main__':
     finder = MDNSFinder()
     threads = []
     for i in range(20):
-        threads.append(Thread(target=run_ad, args=(f"t{i:02}t{i:02}t{i:02}t{i:02}t{i:02}t{i:02}t{i:02}t{i:02}!!", randint(2,6), randint(4,20))))
+        threads.append(Thread(target=run_ad, args=(f"t{i:02}t{i:02}t{i:02}t{i:02}t{i:02}t{i:02}t{i:02}t{i:02}!!", randint(2,6), randint(10, 30))))
     finder.start()
     start = time()
     print(f"Readt: {start}")
@@ -221,7 +284,7 @@ if __name__ == '__main__':
     while started == False or active_count() > 1:
         if active_count() > 1:
             started = True
-        found = finder.get_brokers()
+        found = finder.getBrokerList()
         if any(not s.endswith('.local.') for s in found):
             print(f"Partial: {found}")
 

--- a/endaq/device/mqtt/discovery.py
+++ b/endaq/device/mqtt/discovery.py
@@ -7,58 +7,11 @@ import re
 from time import sleep, time
 from typing import Any, Callable, Dict, List, Optional, Tuple
 from threading import Lock
+from dataclasses import dataclass
 
 from zeroconf import Zeroconf, ServiceBrowser, ServiceInfo, ServiceStateChange
 
 from ..util import levenshtein
-
-class MDNSFinder:
-    _zc = None
-    lock = Lock()
-    _mdns_list = []
-
-    @classmethod
-    def _on_service_state_change(cls, zeroconf: Zeroconf,
-                                service_type: str,
-                                name: str,
-                                state_change: ServiceStateChange):
-        print(f"Called {name} ({service_type}), {state_change}")
-        if state_change == ServiceStateChange.Removed:
-            with cls.lock:
-                if name in cls._mdns_list:
-                    cls._mdns_list.remove(name)
-            return
-        info = zeroconf.get_service_info(service_type, name)
-        if not info:
-            print(f"getinfo failed for {name} ({service_type}) ")
-            return
-        with cls.lock:
-            if name not in cls._mdns_list:
-                cls._mdns_list.append(name)
-
-    @classmethod
-    def start(cls):
-        if cls._zc is not None:
-            return
-        cls._zc = Zeroconf()
-        cls.browser = ServiceBrowser(
-            cls._zc,
-            "_endaq._tcp.local.",
-            handlers=[cls._on_service_state_change],
-        )
-
-    @classmethod
-    def close(cls):
-        cls._zc.close()
-        cls._zc = None
-        with cls.lock:
-            cls._mdns_list = []
-
-    @classmethod
-    def get_brokers(cls):
-        # with cls.lock:
-        brokers = cls._mdns_list
-        return brokers
 
 # ===========================================================================
 #
@@ -69,10 +22,96 @@ DEFAULT_NAME = "Data Collection Box Interface._endaq._tcp.local."
 DEFAULT_NAMES = ["enDAQ Remote Interface*._endaq._tcp.local.",
                  "Data Collection Box Interface*._endaq._tcp.local."]
 SERVICE_TYPE = "_endaq._tcp.local."
+mdns_finders: list["MDNSFinder"] = []
 
 # ===========================================================================
 #
 # ===========================================================================
+
+@dataclass
+class MDNSInfo:
+    name: str
+    serviceType: str
+    host: str
+    port: int
+    properties: dict[bytes, bytes | None]
+
+
+class MDNSFinder:
+    def __init__(self, patterns: Optional[list[str]], timeout=5):
+        self._zc = None
+        self.browser = None
+        self.lock = Lock()
+        self._mdns_list: list[MDNSInfo] = []
+        #TODO: Clarify the intent here, it looks like patterns=None provides the default, but patterns=[None] provides all results
+        if not patterns:
+            patterns = DEFAULT_NAMES[:]
+        elif patterns[0] is None:
+            patterns = None
+        else:
+            # Add service name if the name doesn't have one.
+            patterns = list(patterns)
+            for i, n in enumerate(patterns):
+                patterns[i] = '{}.{}'.format(*splitServiceName(n))
+        self._patterns: list[str] | None = patterns       # TODO: Validate Patterns
+        self._timeout_ms = timeout * 1000
+
+    def _on_service_state_change(self, zeroconf: Zeroconf,
+                                service_type: str,
+                                name: str,
+                                state_change: ServiceStateChange):
+        print(f"Called {name} ({service_type}), {state_change}")
+        if state_change == ServiceStateChange.Removed:
+            with self.lock:
+                if name in self._mdns_list:
+                    self._mdns_list.remove(name)
+            return
+        info = zeroconf.get_service_info(service_type, name, timeout=self._timeout_ms)
+        if not info:
+            print(f"getinfo failed for {name} ({service_type}) ")
+            return
+        with self.lock:
+            if not self._patterns or any(fnmatchcase(info.name, p) for p in self._patterns):
+                if info.name not in self._mdns_list:
+                    self._mdns_list.append(parseServiceInfo(info))
+
+    def start(self):
+        if self._zc is not None:
+            return
+        self._zc = Zeroconf()
+        with self.lock:     # Locking is not really needed here, just being extra safe
+            if not self._patterns:
+                services = [SERVICE_TYPE]
+            else:
+                services = [splitServiceName(n)[1] for n in self._patterns]
+        print(f"Starting discovery with {services=}")
+        self.browser = ServiceBrowser(
+            zc=self._zc,
+            type_=services,
+            handlers=[self._on_service_state_change],
+        )
+
+    def close(self):
+        if self._zc is not None:
+            self.browser.cancel()
+            self._zc.close()
+        self._zc = None
+        with self.lock:
+            self._mdns_list = []
+
+    def get_brokers(self) -> list[MDNSInfo]:
+        with self.lock:
+            if self._patterns and len(self._mdns_list) > 1:
+                # Sort by similarity to patterns
+                self._mdns_list.sort(key=lambda x: min(levenshtein(x.name, p)
+                                                   for p in self._patterns))
+            brokers = self._mdns_list[:]
+        return brokers
+
+    def patterns_match(self, *patterns) -> bool:
+        with self.lock:
+            my_patterns = set(self._patterns)
+        return my_patterns == set(patterns)
 
 
 def splitServiceName(serviceName: str) -> Tuple[str, str]:
@@ -85,7 +124,7 @@ def splitServiceName(serviceName: str) -> Tuple[str, str]:
     return serviceName, SERVICE_TYPE
 
 
-def parseInfo(info: ServiceInfo) -> Dict[str, Any]:
+def parseServiceInfo(info: ServiceInfo) -> MDNSInfo:
     """
     Parse `zeroconf.ServiceInfo` into a dictionary (for use elsewhere as
     keyword arguments). Resulting dictionary contains items `"name"`
@@ -94,15 +133,15 @@ def parseInfo(info: ServiceInfo) -> Dict[str, Any]:
     by the service).
     """
     name, serviceType = splitServiceName(info.name)
-    addr = info.parsed_addresses()
+    addr = info.parsed_addresses()[0]
     # Some services' properties contain null keys
     props = {k: v for k, v in info.properties.items() if k}
-    return {"name": name, "serviceType": serviceType,
-            "host": addr, "port": info.port, "properties": props}
+    return MDNSInfo(name=name, serviceType=serviceType,
+                    host=addr, port=info.port, properties=props)
 
 
 def getBroker(name: str = DEFAULT_NAME,
-              timeout: float = 5) -> Dict[str, Any]:
+              timeout: float = 5) -> MDNSInfo:
     """
     Find a specific enDAQ-advertised MQTT Broker. In the best case, this may
     be marginally faster than `findBrokers()` when looking for a specific
@@ -112,25 +151,13 @@ def getBroker(name: str = DEFAULT_NAME,
     :param timeout: The timeout, in seconds.
     :return: A dictionary of broker information.
     """
-    _basename, serviceType = splitServiceName(name)
-
-    zeroconf = Zeroconf()
-    try:
-        info = zeroconf.get_service_info(serviceType, name,
-                                         timeout=timeout*1000)
-        if not info:
-            raise TimeoutError(f'MQTT Broker "{name}" not found')
-
-        return parseInfo(info)
-
-    finally:
-        zeroconf.close()
+    raise NotImplementedError("Use findBroker, or rewrite this to use MDNSFinder")
 
 
-def findBrokers(*patterns,
+def findBrokers(*patterns: str,
                 scantime: float = 2,
                 timeout: float = 5,
-                callback: Optional[Callable] = None) -> List[Dict[str, Any]]:
+                callback: Optional[Callable] = None) -> List[MDNSInfo]:
     """
     Find enDAQ-advertised MQTT Brokers.
 
@@ -146,69 +173,40 @@ def findBrokers(*patterns,
         The callback function should require no arguments.
     :return: A list of MQTT Brokers.
     """
-    if not patterns:
-        patterns = DEFAULT_NAMES[:]
-    elif patterns[0] is None:
-        patterns = None
-    else:
-        # Add service name if the name doesn't have one.
-        patterns = list(patterns)
-        for i, n in enumerate(patterns):
-            patterns[i] = '{}.{}'.format(*splitServiceName(n))
-
-    found = []
-    zeroconf = Zeroconf()
-
-    def on_service_state_change(zeroconf: Zeroconf,
-                                service_type: str,
-                                name: str,
-                                state_change: ServiceStateChange):
-        if state_change != ServiceStateChange.Removed:
-            info = zeroconf.get_service_info(service_type, name)
-            if not info:
-                return
-            if not patterns or any(fnmatchcase(info.name, p) for p in patterns):
-                found.append(parseInfo(info))
-
-    try:
-        if not patterns:
-            services = [SERVICE_TYPE]
-        else:
-            services = [splitServiceName(n)[1] for n in patterns]
-        browser = ServiceBrowser(zeroconf, services,
-                                 handlers=[on_service_state_change])
-
+    finder = None
+    deadline = 0
+    scanDeadline = time() + scantime
+    for broker in mdns_finders:
+        if broker.patterns_match(patterns):
+            finder = broker
+            break
+    if finder is None:
+        finder = MDNSFinder(*patterns, timeout=timeout)
+        mdns_finders.append(finder)
+        finder.start()
         deadline = time() + timeout
-        scanDeadline = time() + scantime
-        while time() < deadline:
-            if callback and callback():
-                break
-            if found and time() > scanDeadline:
-                break
-            sleep(0.1)
 
-        browser.cancel()
-        if patterns and len(found) > 1:
-            # Sort by similarity to patterns
-            found.sort(key=lambda x: min(levenshtein(x['name'], p)
-                                         for p in patterns))
-        return found
+    while time() < deadline:
+        if callback and callback():
+            break
+        if finder.get_brokers() and time() > scanDeadline:
+            break
+        sleep(0.1)
+    return finder.get_brokers()
 
-    finally:
-        zeroconf.close()
-
-from threading import Thread, active_count
-from random import randint
-
-def run_ad(name, delay, lifetime):
-    from .advertising import Advertiser
-    ad = Advertiser(name, rename=False)
-    sleep(delay)
-    ad.start()
-    sleep(lifetime)
-    ad.stop()
 
 if __name__ == '__main__':
+    from threading import Thread, active_count
+    from random import randint
+
+    def run_ad(name, delay, lifetime):
+        from .advertising import Advertiser
+        ad = Advertiser(name, rename=False)
+        sleep(delay)
+        ad.start()
+        sleep(lifetime)
+        ad.stop()
+
     finder = MDNSFinder()
     threads = []
     for i in range(20):

--- a/endaq/device/mqtt/discovery.py
+++ b/endaq/device/mqtt/discovery.py
@@ -5,14 +5,13 @@ Find an enDAQ MQTT broker.
 from fnmatch import fnmatchcase
 import re
 from time import sleep, time
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Callable, Dict, List, Optional, Tuple
 from threading import Lock
 from dataclasses import dataclass
 import copy
 
 from zeroconf import Zeroconf, ServiceBrowser, ServiceInfo, ServiceStateChange
 
-from ..util import levenshtein
 
 # ===========================================================================
 #
@@ -23,16 +22,18 @@ DEFAULT_NAME = "Data Collection Box Interface._endaq._tcp.local."
 DEFAULT_NAMES = ["enDAQ Remote Interface*._endaq._tcp.local.",
                  "Data Collection Box Interface*._endaq._tcp.local."]
 SERVICE_TYPE = "_endaq._tcp.local."
-MDNS_FINDERS: list["MDNSFinder"] = []
+MDNS_FINDERS: List["MDNSFinder"] = []
 
 # ===========================================================================
 #
 # ===========================================================================
 
+
 @dataclass
 class MDNSInfo:
     """
     Dataclass for organizing info about mDNS services
+
     :param name: Root name of mDNS name, so 'name._endaq._tcp.local.' becomes 'name'
     :param serviceType: Service name of mDNS name, so 'name._endaq._tcp.local.' becomes '_endaq._tcp.local.'
     :param host: list of IP addresses for mDNS advertiser. Generally only the first item is used
@@ -41,13 +42,13 @@ class MDNSInfo:
     """
     name: str
     serviceType: str
-    host: list[str]
+    host: List[str]
     port: int
-    properties: dict[bytes, Optional[bytes]]
+    properties: Dict[bytes, Optional[bytes]]
 
 
 class MDNSFinder:
-    def __init__(self, *patterns, timeout:float=5.0):
+    def __init__(self, *patterns, timeout: float = 5.0):
         """
         Object to handle searching for mDNS hosts. Most of the work is handled by Zeroconf in the background
         :param patterns: Zero or more MQTT Broker names (multiple positional
@@ -58,7 +59,7 @@ class MDNSFinder:
         self._zc = None                         # Holder for Zeroconf object
         self.browser = None                     # Holder for serviceBrowser
         self.lock = Lock()                      # Lock to manage access of mDNS list, which is shared between threads
-        self._mdns: dict[str, MDNSInfo] = {}    # Dict of mDNS items indexed by full name. Don't access this without the lock!!!
+        self._mdns: Dict[str, MDNSInfo] = {}    # Dict of mDNS items indexed by full name. Don't access this without the lock!!!
         #TODO: Clarify the intent here, it looks like patterns=None provides the default, but patterns=[None] provides all results
         if not patterns:
             patterns = DEFAULT_NAMES[:]
@@ -69,17 +70,20 @@ class MDNSFinder:
             patterns = list(patterns)
             for i, n in enumerate(patterns):
                 patterns[i] = '{}.{}'.format(*splitServiceName(n))
-        self._patterns: Optional[list[str]] = patterns       # TODO: Validate Patterns
+        self._patterns: Optional[List[str]] = patterns       # TODO: Validate Patterns
         self._timeout_ms = int(timeout * 1000)
         self.start_time = 0
 
-    def _onServiceStateChange(self, zeroconf: Zeroconf,
+
+    def _onServiceStateChange(self,
+                              zeroconf: Zeroconf,
                               service_type: str,
                               name: str,
                               state_change: ServiceStateChange):
         """
-        Called by Zeroconf serviceBrowser when an mDNS is added, removed, or updated
-        Do not change these parameters or names! They are required by Zeroconf
+        Called by Zeroconf serviceBrowser when an mDNS is added, removed,
+        or updated. Do not change these parameters or names! They are
+        required by Zeroconf.
         """
         if state_change == ServiceStateChange.Removed:
             with self.lock:
@@ -93,11 +97,11 @@ class MDNSFinder:
             return
         with self.lock:
             if not self._patterns or any(fnmatchcase(info.name, p) for p in self._patterns):
-                self._mdns[info.name]=parseServiceInfo(info)
+                self._mdns[info.name] = parseServiceInfo(info)
 
     def start(self):
         """
-        Start searching for the specified mDNS types
+        Start searching for the specified mDNS service types.
         """
         if self._zc is not None:
             return
@@ -114,9 +118,10 @@ class MDNSFinder:
         )
         self.start_time = time()
 
+
     def stop(self):
         """
-        Close out the search and delete all results
+        Close out the search and delete all results.
         """
         if self._zc is not None:
             self.browser.cancel()
@@ -125,22 +130,23 @@ class MDNSFinder:
         with self.lock:
             self._mdns = {}
 
-    def getBrokerDict(self) -> tuple[dict[str, MDNSInfo], list[str]]:
+
+    def getBrokerDict(self) -> Dict[str, MDNSInfo]:
         """
         Copy the dict of brokers and get a separate list of their names
-        :returns dict of the brokers and a sorted list of the keys:
+
+        :returns: A dictionary of the brokers.
         """
         with self.lock:
             # Removing the Levenshtein distance sorting, it looked like we were sorting here, then re-sorting in the broker select
             brokers = copy.deepcopy(self._mdns)
-        # TODO: Consider storing names separately and keeping it sorted if we're using this function a lot
-        names = sorted(brokers.keys())
-        return brokers, names
+        return brokers
 
-    def getBrokerList(self) -> list[MDNSInfo]:
+
+    def getBrokerList(self) -> List[MDNSInfo]:
         """
         Copy the list of brokers
-        :returns list of the brokers:
+        :returns: list of the brokers:
         """
         brokers = []
         with self.lock:
@@ -148,9 +154,10 @@ class MDNSFinder:
                 brokers.append(copy.deepcopy(v))
         return brokers
 
+
     def patternsMatch(self, *patterns) -> bool:
         """
-        See if the specified patterns match what this broker is using
+        See if the specified patterns match what this broker is using.
         """
         with self.lock:
             if self._patterns is None and patterns is None:
@@ -158,7 +165,8 @@ class MDNSFinder:
             my_patterns = set(self._patterns)
         return my_patterns == set(patterns)
 
-    def restart(self, min_lifetime: int=5):
+
+    def restart(self, min_lifetime: int = 5):
         """
         Stop and restart the discovery process unless it has already been started within min_lifetime seconds
         :param min_lifetime: Don't kill the previous process if it was started min_lifetime seconds ago
@@ -181,11 +189,7 @@ def splitServiceName(serviceName: str) -> Tuple[str, str]:
 
 def parseServiceInfo(info: ServiceInfo) -> MDNSInfo:
     """
-    Parse `zeroconf.ServiceInfo` into a dictionary (for use elsewhere as
-    keyword arguments). Resulting dictionary contains items `"name"`
-    (string), `"host"` (list of addresses as strings, IPv4 and IPV6 if
-    available), `"port"` (int), and `"properties"` (dictionary, provided
-    by the service).
+    Parse `zeroconf.ServiceInfo` into an `MDNSInfo` object.
     """
     name, serviceType = splitServiceName(info.name)
     addr = info.parsed_addresses()
@@ -195,6 +199,7 @@ def parseServiceInfo(info: ServiceInfo) -> MDNSInfo:
                     host=addr, port=info.port, properties=props)
 
 
+# noinspection PyUnusedLocal
 def getBroker(name: str = DEFAULT_NAME,
               timeout: float = 5) -> MDNSInfo:
     """
@@ -204,7 +209,7 @@ def getBroker(name: str = DEFAULT_NAME,
 
     :param name: The name of the broker.
     :param timeout: The timeout, in seconds.
-    :return: A dictionary of broker information.
+    :returns: A dictionary of broker information.
     """
     raise NotImplementedError("Use findBroker, or rewrite this to use MDNSFinder")
 
@@ -212,7 +217,8 @@ def getBroker(name: str = DEFAULT_NAME,
 def findBrokers(*patterns: str,
                 scantime: float = 2,
                 timeout: float = 5,
-                callback: Optional[Callable] = None, persistent: bool=False) -> List[MDNSInfo]:
+                callback: Optional[Callable] = None,
+                persistent: bool = False) -> List[MDNSInfo]:
     """
     Find enDAQ-advertised MQTT Brokers.
 
@@ -226,7 +232,10 @@ def findBrokers(*patterns: str,
     :param callback: A function to call repeatedly while scanning. If the
         callback returns `True`, the wait for a response will be cancelled.
         The callback function should require no arguments.
-    :return: A list of MQTT Brokers.
+    :param persistent: If `True`, keep the mDNS finding object open for
+        later use (this can make subsequent discovery faster and more
+        accurate).
+    :returns: A list of MQTT Brokers.
     """
     finder = None
     deadline = 0
@@ -245,7 +254,6 @@ def findBrokers(*patterns: str,
         finder.start()
         deadline = time() + timeout
 
-
     while time() < deadline:
         if callback and callback():
             break
@@ -257,6 +265,7 @@ def findBrokers(*patterns: str,
         finder.stop()
     return broker_list
 
+
 if __name__ == "__main__":
     """
     Just print added and removed mDNS items.
@@ -267,7 +276,7 @@ if __name__ == "__main__":
     print(f"Scanning for mDNS Hosts:")
     while True:
         old_hosts = hosts
-        hosts, _ = finder.getBrokerDict()
+        hosts = finder.getBrokerDict()
         alive = []
         for host_id in hosts:
             if host_id in old_hosts:

--- a/endaq/device/mqtt/discovery.py
+++ b/endaq/device/mqtt/discovery.py
@@ -51,6 +51,11 @@ class MDNSInfo:
     properties: Dict[bytes, Optional[bytes]]
 
 
+    def __getitem__(self, k):
+        # For backwards compatibility with earlier version that got brokers as dicts
+        return self.__dict__[k]
+
+
 class MDNSFinder:
     def __init__(self, *patterns, timeout: float = 5.0):
         """
@@ -209,9 +214,7 @@ def parseServiceInfo(info: ServiceInfo) -> MDNSInfo:
 def getBroker(name: str = DEFAULT_NAME,
               timeout: float = 5) -> MDNSInfo:
     """
-    Find a specific enDAQ-advertised MQTT Broker. In the best case, this may
-    be marginally faster than `findBrokers()` when looking for a specific
-    broker.
+    Find a specific enDAQ-advertised MQTT Broker.
 
     :param name: The name of the broker.
     :param timeout: The timeout, in seconds.

--- a/endaq/device/mqtt/discovery.py
+++ b/endaq/device/mqtt/discovery.py
@@ -81,7 +81,6 @@ class MDNSFinder:
         Called by Zeroconf serviceBrowser when an mDNS is added, removed, or updated
         Do not change these parameters or names! They are required by Zeroconf
         """
-        print(f"Called {name} ({service_type}), {state_change}")
         if state_change == ServiceStateChange.Removed:
             with self.lock:
                 if name in self._mdns:
@@ -108,7 +107,6 @@ class MDNSFinder:
                 services = [SERVICE_TYPE]
             else:
                 services = [splitServiceName(n)[1] for n in self._patterns]
-        print(f"Starting discovery with {services=}")
         self.browser = ServiceBrowser(
             zc=self._zc,
             type_=services,

--- a/endaq/device/mqtt/discovery.py
+++ b/endaq/device/mqtt/discovery.py
@@ -256,3 +256,24 @@ def findBrokers(*patterns: str,
     if not keep_open:
         finder.stop()
     return broker_list
+
+if __name__ == "__main__":
+    """
+    Just print added and removed mDNS items.
+    """
+    finder = MDNSFinder(None)
+    finder.start()
+    hosts = {}
+    print(f"Scanning for mDNS Hosts:")
+    while True:
+        old_hosts = hosts
+        hosts, _ = finder.getBrokerDict()
+        alive = []
+        for host_id in hosts:
+            if host_id in old_hosts:
+                alive.append(host_id)
+            else:
+                print(f"Found new host: {host_id} at {hosts[host_id].host}")
+        dead = [x for x in old_hosts if x not in alive]
+        for host_id in dead:
+            print(f"Host removed: {host_id} at {old_hosts[host_id].host}")

--- a/endaq/device/mqtt/mqtt_interface.py
+++ b/endaq/device/mqtt/mqtt_interface.py
@@ -30,6 +30,7 @@ from threading import Event, Thread
 from time import sleep, time
 from typing import Any, BinaryIO, Callable, Dict, List, Optional, Tuple, Union
 from weakref import WeakValueDictionary
+from dataclasses import asdict
 
 import paho.mqtt.client as mqtt
 from serial import PortNotOpenError
@@ -191,7 +192,7 @@ class MQTTConnector:
         if not brokers:
             raise NameError(f'No brokers found matching name pattern(s) {patterns!r}')
 
-        broker = brokers[0]
+        broker = asdict(brokers[0])
         broker.update(kwargs)
         return cls(**broker)
 


### PR DESCRIPTION
This also brings in the advertising changes from #161 so I'm closing that.
* Remove the threading from the Advertising object, it is all handled by Zeroconf
* mDNS discovery can be handled with a persistent MDNSFinder object (endaq-config-gui has been updated for this)
* Added MDNSInfo Dataclass object to simplify the handling of information
* Calling discovery.py will have it browse for mDNS advertisements