### PR TITLE
Added option to specify network interface in `getMyIP()`

### DIFF
--- a/endaq/device/util.py
+++ b/endaq/device/util.py
@@ -8,11 +8,14 @@ import errno
 from functools import wraps
 import os.path
 import pathlib
+import re
 import shutil
 from threading import get_native_id, RLock
 from time import sleep, time
 from typing import Any, ByteString, Callable, Dict, Optional, Tuple, Union
 import socket
+
+import ifaddr
 
 from .response_codes import CommandResponseCode
 from .exceptions import DeviceError
@@ -168,23 +171,46 @@ def levenshtein(a: str, b: str) -> int:
 #
 # ===========================================================================
 
-def getMyIP() -> str:
+def getMyIP(iface: Optional[str] = None,
+            timeout: Optional[int] = 3) -> str:
     """ Retrieve the computer's IP address (v4).
+
+        :param iface: The name of a specific network interface to use. If
+            `iface` is a regular expression, the first match will be used
+            (e.g., ``"wlan0|mlan0"`` will return the IP of ``wlan0`` if both
+            are connected).
+        :param timeout: The amount of time, in seconds, to wait for the
+            specified `iface` to become available (if not immediately
+            present). If `None`, wait indefinitely. Only applicable when
+            `iface` is specified.
     """
+    # FUTURE: Multiple interfaces/IPs and/or IPv6
+    if iface:
+        timeout = float('inf') if timeout is None else timeout
+        deadline = time() + timeout
+        regex = re.compile(iface)
+
+        while True:
+            for adapter in ifaddr.get_adapters():
+                if not adapter.ips:
+                    continue
+                for ip in adapter.ips:
+                    if regex.match(ip.nice_name):
+                        # Get IPv4 address (IPv6 is a tuple)
+                        if isinstance(ip.ip, str):
+                            return ip.ip
+            if time() >= deadline:
+                break
+            sleep(.5)
+
     try:
-        # More accurate, but may fail in some conditions
         with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
-            s.settimeout(0)
             s.connect(("8.8.8.8", 80))
             return s.getsockname()[0]
-    except (socket.error, OSError):
-        try:
-            # Alternate method (safer, but may return loopback on some systems)
-            name = socket.gethostname()
-            return socket.gethostbyname(name)
-        except (socket.error, OSError) as err:
-            logger.error(f"Could not get IP, defaulting to 127.0.0.1 ({err!r})")
-            return '127.0.0.1'
+    except (socket.error, TimeoutError) as err:
+        logger.error(f'Failed to get IP address, using localhost: {err!r}')
+
+    return '127.0.0.1'
 
 
 def makeClientID(base: str) -> str:
@@ -230,7 +256,11 @@ def waitfor(func: Callable,
     raise TimeoutError
 
 
-def decodeAttr(data, obj):
+def decodeAttr(data: Dict[str, Any], obj: Any):
+    """ Decode an EBML `Attribute` element (defined in several enDAQ/Mide
+        schemata) and update an object's `attributes` attribute. Used to
+        process some special-case metadata.
+    """
     name = data.pop('AttributeName')
 
     attrs = getattr(obj, 'attributes', None)

--- a/endaq/device/util.py
+++ b/endaq/device/util.py
@@ -172,19 +172,24 @@ def levenshtein(a: str, b: str) -> int:
 # ===========================================================================
 
 def getMyIP(iface: Optional[str] = None,
-            timeout: Optional[int] = 3) -> str:
+            timeout: Optional[int] = 3,
+            default: str = '127.0.0.1') -> str:
     """ Retrieve the computer's IP address (v4).
 
-        :param iface: The name of a specific network interface to use. If
-            `iface` is a regular expression, the first match will be used
-            (e.g., ``"wlan0|mlan0"`` will return the IP of ``wlan0`` if both
-            are connected).
+        :param iface: The name of a specific network interface/adapter to
+            use. If `iface` is a regular expression, the first match will
+            be used (e.g., ``"wlan0|mlan0"`` will return the IP of ``wlan0``
+            if both are connected).
         :param timeout: The amount of time, in seconds, to wait for the
             specified `iface` to become available (if not immediately
             present). If `None`, wait indefinitely. Only applicable when
             `iface` is specified.
+        :param default: The default network interface to use if none
+            could be found.
     """
     # FUTURE: Multiple interfaces/IPs and/or IPv6
+
+    # Find a specific interface/adapter
     if iface:
         timeout = float('inf') if timeout is None else timeout
         deadline = time() + timeout
@@ -200,17 +205,28 @@ def getMyIP(iface: Optional[str] = None,
                         if isinstance(ip.ip, str):
                             return ip.ip
             if time() >= deadline:
+                logger.debug(f'Could not find network interface {iface!r}, '
+                             "attempting to get active interface's IP")
                 break
             sleep(.5)
 
+    # Get the primary interface's IP
     try:
+        # More accurate, but may fail in some conditions
         with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+            s.settimeout(0)
             s.connect(("8.8.8.8", 80))
             return s.getsockname()[0]
-    except (socket.error, TimeoutError) as err:
-        logger.error(f'Failed to get IP address, using localhost: {err!r}')
-
-    return '127.0.0.1'
+    except (socket.error, OSError):
+        try:
+            # Alternate method (safer, but may return loopback on some systems)
+            name = socket.gethostname()
+            return socket.gethostbyname(name)
+        except (socket.error, OSError) as err:
+            if default is None:
+                raise
+            logger.error(f"Could not get IP, defaulting to {default} ({err!r})")
+            return default
 
 
 def makeClientID(base: str) -> str:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 ebmlite
 # idelib>=3.2.9
 idelib @ git+https://github.com/MideTechnology/idelib.git@develop
+ifaddr>=0.1.7
 numpy>=1.19.4
 paho-mqtt>=2.1.0
 psutil >=5.5.0; sys_platform == "linux" or sys_platform=="darwin"

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ INSTALL_REQUIRES = [
     'ebmlite>=3.3.0',
     # 'idelib>=3.2.9',
     'idelib @ git+https://github.com/MideTechnology/idelib.git@develop',
+    'ifaddr>=0.1.7',
     'numpy>=1.19.4',
     'paho-mqtt>=2.1.0',
     'psutil >=5.5.0; sys_platform == "linux" or sys_platform=="darwin"',


### PR DESCRIPTION
This is primarily intended for Gateway hardware which may have multiple network interfaces active simultaneously.