### PR TITLE
Added Advertiser clean shutdown on SIGTERM, compatibilty fixes, etc.

### DIFF
--- a/endaq/device/mqtt/advertising.py
+++ b/endaq/device/mqtt/advertising.py
@@ -6,6 +6,7 @@ to announce the name and IP address of the MQTT Broker via zeroconf/mDNS.
 import itertools
 import json
 import logging
+import signal
 import socket
 from time import time, sleep
 from typing import Any, Callable, Dict, Optional
@@ -68,6 +69,25 @@ class Advertiser:
 
         self.info = None
         self.zeroconf = None
+
+        signal.signal(signal.SIGTERM, self._signal_SIGTERM)
+
+
+    def _signal_SIGTERM(self, _signum, _frame):
+        """ SIGTERM handler: cleanly shut down if process terminated.
+        """
+        logger.debug('Received termination signal (SIGTERM)')
+        self.stop()
+
+
+    def __repr__(self) -> str:
+        """ Return repr(self).
+        """
+        name = f'{type(self).__name__} {self.fullName!r}'
+        if self.is_alive():
+            return f'<{name} (running)>'
+        else:
+            return f'<{name} (stopped)>'
 
 
     def stop(self) -> bool:
@@ -137,6 +157,15 @@ class Advertiser:
                 other_ttl=1125
             )
             self.zeroconf.register_service(self.info)
+
+
+    def is_alive(self) -> bool:
+        """ Is the advetiser running?
+        """
+        try:
+            return self.zeroconf.started
+        except AttributeError:
+            return False
 
 
 # ===========================================================================

--- a/endaq/device/mqtt/discovery.py
+++ b/endaq/device/mqtt/discovery.py
@@ -3,7 +3,7 @@ Find an enDAQ MQTT broker.
 """
 
 import copy
-from dataclasses import dataclass
+from dataclasses import dataclass, asdict
 from fnmatch import fnmatchcase
 import logging
 import re
@@ -52,9 +52,22 @@ class MDNSInfo:
     properties: Dict[bytes, Optional[bytes]]
 
 
+    # For backwards compatibility with earlier version that returned brokers as dicts
+
     def __getitem__(self, k):
-        # For backwards compatibility with earlier version that got brokers as dicts
-        return self.__dict__[k]
+        return asdict(self)[k]
+
+    def get(self, *args):
+        return asdict(self).get(*args)
+
+    def keys(self):
+        return asdict(self).keys()
+
+    def values(self):
+        return asdict(self).values()
+
+    def items(self):
+        return asdict(self).values()
 
 
 class MDNSFinder:
@@ -218,7 +231,7 @@ def parseServiceInfo(info: ServiceInfo) -> MDNSInfo:
                     host=addr, port=info.port, properties=props)
 
 
-# noinspection PyUnusedLocal
+# noinspection PyUnusedLocal,unused-parameter
 def getBroker(name: str = DEFAULT_NAME,
               timeout: float = 5) -> MDNSInfo:
     """

--- a/endaq/device/mqtt/discovery.py
+++ b/endaq/device/mqtt/discovery.py
@@ -9,7 +9,8 @@ import logging
 import re
 from threading import RLock
 from time import sleep, time
-from typing import Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
+import warnings
 
 from zeroconf import Zeroconf, ServiceBrowser, ServiceInfo, ServiceStateChange
 
@@ -34,6 +35,7 @@ MDNS_FINDERS: List["MDNSFinder"] = []
 # ===========================================================================
 
 
+# noinspection deprecation
 @dataclass
 class MDNSInfo:
     """
@@ -52,22 +54,28 @@ class MDNSInfo:
     properties: Dict[bytes, Optional[bytes]]
 
 
-    # For backwards compatibility with earlier version that returned brokers as dicts
+    # For backwards compatibility with earlier version that returned brokers as dicts.
+    # These will be removed in the future.
+
+    def _asdict(self) -> Dict[str, Any]:
+        warnings.warn("mDNS info now returned as an MDNSInfo object; dict methods will be deprecated",
+                      DeprecationWarning)
+        return asdict(self)
 
     def __getitem__(self, k):
-        return asdict(self)[k]
+        return self._asdict()[k]
 
     def get(self, *args):
-        return asdict(self).get(*args)
+        return self._asdict().get(*args)
 
     def keys(self):
-        return asdict(self).keys()
+        return self._asdict().keys()
 
     def values(self):
-        return asdict(self).values()
+        return self._asdict().values()
 
     def items(self):
-        return asdict(self).values()
+        return self._asdict().values()
 
 
 class MDNSFinder:

--- a/endaq/device/mqtt/manager.py
+++ b/endaq/device/mqtt/manager.py
@@ -676,7 +676,7 @@ class MQTTDeviceManager(MQTTClient):
     # Commands: Methods for each command handled by the `CommandClient`.
     # =======================================================================
 
-    # noinspection PyUnusedLocal
+    # noinspection PyUnusedLocal,unused-parameter
     def command_GetDeviceList(
                 self,
                 payload: Any,
@@ -702,7 +702,7 @@ class MQTTDeviceManager(MQTTClient):
         return {'DeviceList': {'DeviceListItem': devices}}, None, None
 
 
-    # noinspection PyUnusedLocal
+    # noinspection PyUnusedLocal,unused-parameter
     def command_GetIDEHeader(
                 self,
                 payload: Any,
@@ -734,7 +734,7 @@ class MQTTDeviceManager(MQTTClient):
         return response, None, None
 
 
-    # noinspection PyUnusedLocal
+    # noinspection PyUnusedLocal,unused-parameter
     def command_Shutdown(
                 self,
                 payload: Any,


### PR DESCRIPTION
* Added `Advertiser` clean shutdown on SIGTERM
* Added `is_alive()` to `Advertiser` (some code still used it)
* Added `dict` methods `MDNSInfo` for backwards compatibility (some code uses mDNS info like a  dict)
* Added `Advertiser.__repr__()` that includes status
* Minor cleanup (linter directives)